### PR TITLE
Implement associateCustomer API

### DIFF
--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersService.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersService.java
@@ -7,6 +7,18 @@ import com.comerzzia.unide.api.web.model.customer.DeactivateCustomer;
 
 public interface UnideLyCustomersService extends LyCustomersService {
 
-	void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException;
+        void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException;
+
+        /**
+         * Associates an anonymous loyal customer with the personal information
+         * provided. The JSON structure matches the insert service.
+         *
+         * @param loyalCustomer full customer data
+         * @param datosSesion   session data
+         * @return updated customer information
+         */
+        com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO associateCustomer(
+                        com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO loyalCustomer,
+                        IDatosSesion datosSesion) throws ApiException;
 
 }

--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
@@ -109,7 +109,7 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
 
 	@Override
 	@Transactional(rollbackFor = Exception.class)
-	public void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException {
+        public void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException {
 		if(deactivateModel == null) throw new BadRequestException("La peticion es vacía o nula");
 		
 		LyCustomerEntity loyalCustomer = selectByPrimaryKey(datosSesion, deactivateModel.getLyCustomerId());
@@ -185,7 +185,90 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
 			log.error("deactivateLoyalCustomer() - " + msg, e);
 
 			throw new ApiException(msg, e);
-		}
+                }
 
-	}
+        }
+
+        @Override
+        @Transactional(rollbackFor = Exception.class)
+        public LyCustomerDTO associateCustomer(LyCustomerDTO loyalCustomer, IDatosSesion datosSesion) throws ApiException {
+                if (loyalCustomer == null) {
+                        throw new BadRequestException("La peticion es vacía o nula");
+                }
+
+                if (loyalCustomer.getCards() == null || loyalCustomer.getCards().isEmpty() ||
+                                StringUtils.isBlank(loyalCustomer.getCards().get(0).getCardCode())) {
+                        throw new BadRequestException("No se ha indicado la tarjeta de fidelizacion");
+                }
+
+                if (loyalCustomer.getNewCustomerAccess() != null &&
+                                StringUtils.isNotBlank(loyalCustomer.getNewCustomerAccess().getUser())) {
+                        String user = loyalCustomer.getNewCustomerAccess().getUser();
+                        user = user.replace("_", "").replace("@", "");
+                        loyalCustomer.getNewCustomerAccess().setUser(user);
+                }
+
+                try {
+                        String cardCode = loyalCustomer.getCards().get(0).getCardCode();
+
+                        com.comerzzia.api.loyalty.persistence.cards.CardExample cardExample =
+                                        new com.comerzzia.api.loyalty.persistence.cards.CardExample(datosSesion);
+                        cardExample.or().andCardCodeEqualTo(cardCode).andFechaBajaIsNull();
+
+                        List<CardEntity> cards = cardsService.selectByExample(datosSesion, cardExample);
+                        if (cards.isEmpty()) {
+                                throw new NotFoundException();
+                        }
+
+                        CardEntity card = cards.get(0);
+                        if (card.getLoyalCustomerId() == null) {
+                                throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE,
+                                                "Tarjeta sin fidelizado asociado");
+                        }
+
+                        LyCustomerEntity dbCustomer = selectByPrimaryKey(datosSesion, card.getLoyalCustomerId());
+                        if (dbCustomer == null) {
+                                throw new NotFoundException();
+                        }
+
+                        if (StringUtils.isNotBlank(dbCustomer.getName()) || StringUtils.isNotBlank(dbCustomer.getLastName())) {
+                                throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE,
+                                                "La tarjeta ya está asociada a un fidelizado");
+                        }
+
+                        if (loyalCustomer.getCollectives() == null) {
+                                loyalCustomer.setCollectives(new java.util.ArrayList<>());
+                        }
+                        boolean hasReg = loyalCustomer.getCollectives().stream()
+                                        .anyMatch(c -> "REG".equalsIgnoreCase(c.getCollectiveCode()));
+                        if (!hasReg) {
+                                com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveEntity reg =
+                                                new com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveEntity();
+                                reg.setCollectiveCode("REG");
+                                loyalCustomer.getCollectives().add(reg);
+                        }
+
+                        loyalCustomer.setLyCustomerId(dbCustomer.getLyCustomerId());
+                        loyalCustomer.setLyCustomerCode(dbCustomer.getLyCustomerCode());
+
+                        mapper.updateByPrimaryKey(loyalCustomer);
+
+                        LoyalCustomerVersion loyalCustomerVersion = new LoyalCustomerVersion(loyalCustomer.getLyCustomerId());
+                        fidVersionControlService.checkLoyalCustomersVersion(datosSesion, loyalCustomerVersion);
+
+                        return selectByPrimaryKey(datosSesion, loyalCustomer.getLyCustomerId());
+                }
+                catch (ApiException e) {
+                        throw e;
+                }
+                catch (PersistenceException e) {
+                        if (PersistenceExceptionFactory.getPersistenceExpception(e).isConstraintViolationException()) {
+                                throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, e.getMessage());
+                        }
+                        throw new ApiException(e.getMessage(), e);
+                }
+                catch (Exception e) {
+                        throw new ApiException(e.getMessage(), e);
+                }
+        }
 }

--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
@@ -236,14 +236,14 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                                                 "La tarjeta ya está asociada a un fidelizado");
                         }
 
-                        if (loyalCustomer.getCollectives() == null) {
-                                loyalCustomer.setCollectives(new java.util.ArrayList<>());
+                       if (loyalCustomer.getCollectives() == null) {
+                               loyalCustomer.setCollectives(new java.util.ArrayList<>());
                         }
                         boolean hasReg = loyalCustomer.getCollectives().stream()
                                         .anyMatch(c -> "REG".equalsIgnoreCase(c.getCollectiveCode()));
                         if (!hasReg) {
-                                com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveKey reg =
-                                                new com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveKey();
+                                com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveDTO reg =
+                                                new com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveDTO();
                                 reg.setCollectiveCode("REG");
                                 loyalCustomer.getCollectives().add(reg);
                         }
@@ -252,6 +252,39 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                         loyalCustomer.setLyCustomerCode(dbCustomer.getLyCustomerCode());
 
                         mapper.updateByPrimaryKey(loyalCustomer);
+
+                        if (loyalCustomer.getContacts() != null) {
+                                for (LoyalCustomerContactEntity contact : loyalCustomer.getContacts()) {
+                                        contact.setLoyalCustomerId(loyalCustomer.getLyCustomerId());
+                                        contactsService.insert(contact, datosSesion);
+                                }
+                        }
+
+                        if (loyalCustomer.getCustomerLink() != null) {
+                                loyalCustomer.getCustomerLink().setLyCustomerId(loyalCustomer.getLyCustomerId());
+                                loyalCustomer.getCustomerLink().setActivityUid(datosSesion.getUidActividad());
+                                linksService.insert(loyalCustomer.getCustomerLink(), datosSesion);
+                        }
+
+                        if (loyalCustomer.getAccess() != null) {
+                                loyalCustomer.getAccess().setLoyalCustomerId(loyalCustomer.getLyCustomerId());
+                                accessService.insert(loyalCustomer.getAccess(), datosSesion);
+                        }
+
+                        if (loyalCustomer.getCollectives() != null) {
+                                for (com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveDTO collective : loyalCustomer.getCollectives()) {
+                                        collective.setLoyalCustomerId(loyalCustomer.getLyCustomerId());
+                                        collectivesService.insert(collective, datosSesion);
+                                }
+                        }
+
+                        if (loyalCustomer.getTags() != null) {
+                                for (EtiquetaBean tag : loyalCustomer.getTags()) {
+                                        tag.setIdClaseEtiquetaEnlazada("F_FIDELIZADOS_TBL.ID_FIDELIZADO");
+                                        tag.setIdObjetoEtiquetaEnlazada(loyalCustomer.getLyCustomerId().toString());
+                                        customerTagsService.insertTagLink(tag, datosSesion);
+                                }
+                        }
 
                         LoyalCustomerVersion loyalCustomerVersion = new LoyalCustomerVersion(loyalCustomer.getLyCustomerId());
                         fidVersionControlService.checkLoyalCustomersVersion(datosSesion, loyalCustomerVersion);

--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
@@ -197,15 +197,15 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                 }
 
                 if (loyalCustomer.getCards() == null || loyalCustomer.getCards().isEmpty() ||
-                                StringUtils.isBlank(loyalCustomer.getCards().get(0).getCardCode())) {
+                                StringUtils.isBlank(loyalCustomer.getCards().get(0).getCardNumber())) {
                         throw new BadRequestException("No se ha indicado la tarjeta de fidelizacion");
                 }
 
-                if (loyalCustomer.getNewCustomerAccess() != null &&
-                                StringUtils.isNotBlank(loyalCustomer.getNewCustomerAccess().getUser())) {
-                        String user = loyalCustomer.getNewCustomerAccess().getUser();
+                if (loyalCustomer.getAccess() != null &&
+                                StringUtils.isNotBlank(loyalCustomer.getAccess().getUser())) {
+                        String user = loyalCustomer.getAccess().getUser();
                         user = user.replace("_", "").replace("@", "");
-                        loyalCustomer.getNewCustomerAccess().setUser(user);
+                        loyalCustomer.getAccess().setUser(user);
                 }
 
                 try {
@@ -221,12 +221,12 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                         }
 
                         CardEntity card = cards.get(0);
-                        if (card.getLoyalCustomerId() == null) {
+                        if (card.getLyCustomerId() == null) {
                                 throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE,
                                                 "Tarjeta sin fidelizado asociado");
                         }
 
-                        LyCustomerEntity dbCustomer = selectByPrimaryKey(datosSesion, card.getLoyalCustomerId());
+                        LyCustomerEntity dbCustomer = selectByPrimaryKey(datosSesion, card.getLyCustomerId());
                         if (dbCustomer == null) {
                                 throw new NotFoundException();
                         }

--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
@@ -209,11 +209,11 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                 }
 
                 try {
-                        String cardCode = loyalCustomer.getCards().get(0).getCardCode();
+                String cardNumber = loyalCustomer.getCards().get(0).getCardNumber();
 
-                        com.comerzzia.api.loyalty.persistence.cards.CardExample cardExample =
-                                        new com.comerzzia.api.loyalty.persistence.cards.CardExample(datosSesion);
-                        cardExample.or().andCardCodeEqualTo(cardCode).andFechaBajaIsNull();
+                com.comerzzia.api.loyalty.persistence.cards.CardExample cardExample =
+                                new com.comerzzia.api.loyalty.persistence.cards.CardExample(datosSesion);
+                cardExample.or().andNumeroTarjetaEqualTo(cardNumber).andFechaBajaIsNull();
 
                         List<CardEntity> cards = cardsService.selectByExample(datosSesion, cardExample);
                         if (cards.isEmpty()) {
@@ -242,8 +242,8 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                         boolean hasReg = loyalCustomer.getCollectives().stream()
                                         .anyMatch(c -> "REG".equalsIgnoreCase(c.getCollectiveCode()));
                         if (!hasReg) {
-                                com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveEntity reg =
-                                                new com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveEntity();
+                                com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveKey reg =
+                                                new com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveKey();
                                 reg.setCollectiveCode("REG");
                                 loyalCustomer.getCollectives().add(reg);
                         }
@@ -256,7 +256,7 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
                         LoyalCustomerVersion loyalCustomerVersion = new LoyalCustomerVersion(loyalCustomer.getLyCustomerId());
                         fidVersionControlService.checkLoyalCustomersVersion(datosSesion, loyalCustomerVersion);
 
-                        return selectByPrimaryKey(datosSesion, loyalCustomer.getLyCustomerId());
+                        return selectDTOByPrimaryKey(loyalCustomer.getLyCustomerId(), datosSesion);
                 }
                 catch (ApiException e) {
                         throw e;

--- a/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
+++ b/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
@@ -4,6 +4,7 @@ import javax.annotation.Resource;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -15,6 +16,7 @@ import com.comerzzia.api.core.service.exception.ApiException;
 import com.comerzzia.api.core.service.util.ComerzziaDatosSesion;
 import com.comerzzia.unide.api.services.customers.UnideLyCustomersService;
 import com.comerzzia.unide.api.web.model.customer.DeactivateCustomer;
+import com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -31,9 +33,9 @@ public class UnideCustomersResource {
 	@Autowired
 	protected UnideLyCustomersService service;
 
-	@PUT
-	@Path("/{lyCustomerId}/deactivate")
-	public void deleteLoyalCustomer(@Valid DeactivateCustomer record) throws ApiException {
+        @PUT
+        @Path("/{lyCustomerId}/deactivate")
+        public void deleteLoyalCustomer(@Valid DeactivateCustomer record) throws ApiException {
 		try {
 			service.deactivateLoyalCustomer(record, datosSesionRequest.getDatosSesionBean());
 		}
@@ -42,6 +44,19 @@ public class UnideCustomersResource {
 		}
 		catch (Exception e) {
 			throw new ApiException(e.getMessage(), e);
-		}
-	}
+        }
+
+        @POST
+        @Path("/associateCustomer")
+        public LyCustomerDTO associateCustomer(@Valid LyCustomerDTO record) throws ApiException {
+                try {
+                        return service.associateCustomer(record, datosSesionRequest.getDatosSesionBean());
+                }
+                catch (ApiException e) {
+                        throw e;
+                }
+                catch (Exception e) {
+                        throw new ApiException(e.getMessage(), e);
+                }
+        }
 }

--- a/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
+++ b/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
@@ -36,14 +36,15 @@ public class UnideCustomersResource {
         @PUT
         @Path("/{lyCustomerId}/deactivate")
         public void deleteLoyalCustomer(@Valid DeactivateCustomer record) throws ApiException {
-		try {
-			service.deactivateLoyalCustomer(record, datosSesionRequest.getDatosSesionBean());
-		}
-		catch (ApiException e) {
-			throw e;
-		}
-		catch (Exception e) {
-			throw new ApiException(e.getMessage(), e);
+                try {
+                        service.deactivateLoyalCustomer(record, datosSesionRequest.getDatosSesionBean());
+                }
+                catch (ApiException e) {
+                        throw e;
+                }
+                catch (Exception e) {
+                        throw new ApiException(e.getMessage(), e);
+                }
         }
 
         @POST


### PR DESCRIPTION
## Summary
- add `associateCustomer` endpoint to customers resource for registering card-holders
- document method in service interface
- implement update logic in service implementation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662f3c4440832bab683a43f42c08df