### PR TITLE
Add associateCustomer endpoint

### DIFF
--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersService.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersService.java
@@ -4,9 +4,13 @@ import com.comerzzia.api.core.service.exception.ApiException;
 import com.comerzzia.api.loyalty.service.customers.LyCustomersService;
 import com.comerzzia.core.servicios.sesion.IDatosSesion;
 import com.comerzzia.unide.api.web.model.customer.DeactivateCustomer;
+import com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO;
 
 public interface UnideLyCustomersService extends LyCustomersService {
 
-	void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException;
+        void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException;
+
+       LyCustomerDTO associateCustomer(LyCustomerDTO loyalCustomer, IDatosSesion datosSesion)
+                       throws ApiException;
 
 }

--- a/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
+++ b/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
@@ -4,6 +4,7 @@ import javax.annotation.Resource;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -29,11 +30,11 @@ public class UnideCustomersResource {
 	protected ComerzziaDatosSesion datosSesionRequest;
 
 	@Autowired
-	protected UnideLyCustomersService service;
+        protected UnideLyCustomersService service;
 
 	@PUT
 	@Path("/{lyCustomerId}/deactivate")
-	public void deleteLoyalCustomer(@Valid DeactivateCustomer record) throws ApiException {
+        public void deleteLoyalCustomer(@Valid DeactivateCustomer record) throws ApiException {
 		try {
 			service.deactivateLoyalCustomer(record, datosSesionRequest.getDatosSesionBean());
 		}
@@ -42,6 +43,21 @@ public class UnideCustomersResource {
 		}
 		catch (Exception e) {
 			throw new ApiException(e.getMessage(), e);
-		}
-	}
+                }
+        }
+
+        @POST
+        @Path("/createCustomer")
+        public com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO associateCustomer(
+                        com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO record) throws ApiException {
+                try {
+                        return service.associateCustomer(record, datosSesionRequest.getDatosSesionBean());
+                }
+                catch (ApiException e) {
+                        throw e;
+                }
+                catch (Exception e) {
+                        throw new ApiException(e.getMessage(), e);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- add COD_COLECTIVO_REGISTRO constant
- implement associateCustomer service method
- expose associateCustomer endpoint via POST /createCustomer
- fix exception handling in associateCustomer implementation

## Testing
- `mvn test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1cef650832b8baf68936bad742f