### PR TITLE
Adjust AssociateCustomerRequest

### DIFF
--- a/src/main/java/com/comerzzia/unide/api/web/model/customer/AssociateCustomerRequest.java
+++ b/src/main/java/com/comerzzia/unide/api/web/model/customer/AssociateCustomerRequest.java
@@ -1,69 +1,20 @@
 package com.comerzzia.unide.api.web.model.customer;
 
-import java.util.Date;
 import java.util.List;
+
+import com.comerzzia.api.loyalty.web.model.customer.NewCustomer;
 
 import lombok.Data;
 
+/**
+ * Request body used to associate a loyalty customer. It extends the
+ * {@link NewCustomer} model provided by the loyalty API and only adds the
+ * information related to the cards that must be associated with the customer.
+ */
 @Data
-public class AssociateCustomerRequest {
-    private String lyCustomerCode;
-    private String name;
-    private String lastName;
-    private String address;
-    private String city;
-    private String location;
-    private String province;
-    private String postalCode;
-    private String countryCode;
-    private String identificationTypeCode;
-    private String vatNumber;
-    private String remarks;
-    private Date dateOfBirth;
-    private String genderName;
-    private String maritalStatusCode;
-    private Boolean active;
-    private String languageCode;
-    private List<Collective> collectives;
-    private List<Contact> contacts;
-    private List<Tag> tags;
-    private CustomerLink customerLink;
-    private NewCustomerAccess newCustomerAccess;
+public class AssociateCustomerRequest extends NewCustomer {
+    /** Cards that will be associated with the customer. */
     private List<Card> cards;
-
-    @Data
-    public static class Collective {
-        private String collectiveCode;
-        private String collectiveDes;
-    }
-
-    @Data
-    public static class Contact {
-        private String contactTypeCode;
-        private String value;
-        private Boolean getNotifications;
-        private Boolean comGetNotifications;
-    }
-
-    @Data
-    public static class Tag {
-        private String tagUid;
-        private String tag;
-        private Integer priority;
-    }
-
-    @Data
-    public static class CustomerLink {
-        private String classUid;
-        private String objectUid;
-        private Long lyCustomerId;
-    }
-
-    @Data
-    public static class NewCustomerAccess {
-        private String user;
-        private String password;
-    }
 
     @Data
     public static class Card {


### PR DESCRIPTION
## Summary
- extend `AssociateCustomerRequest` from the API's `NewCustomer`
- keep only card information as extra fields

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686cc0dd2560832ba13518d0b3d98c74