### PR TITLE
Implement customer association refactor

### DIFF
--- a/src/main/java/com/comerzzia/unide/api/services/customers/NewCustomerToFidelizadoConverter.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/NewCustomerToFidelizadoConverter.java
@@ -1,0 +1,54 @@
+package com.comerzzia.unide.api.services.customers;
+
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeToken;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO;
+import com.comerzzia.api.loyalty.persistence.customers.access.LoyalCustomerAccessEntityDTO;
+import com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveDTO;
+import com.comerzzia.api.loyalty.persistence.customers.contacttypes.LoyalCustomerContactEntity;
+import com.comerzzia.api.loyalty.persistence.customers.links.LoyalCustomerLinkEntity;
+import com.comerzzia.api.loyalty.web.model.customer.NewCustomer;
+import com.comerzzia.api.loyalty.web.model.customertag.FidelizadoEtiquetaBeanConverter;
+
+@Component
+public class NewCustomerToFidelizadoConverter {
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @Autowired
+    private FidelizadoEtiquetaBeanConverter fidelizadoEtiquetaBeanConverter;
+
+    public LyCustomerDTO convert(NewCustomer newCustomer) {
+        LyCustomerDTO fidelizado = modelMapper.map(newCustomer, LyCustomerDTO.class);
+
+        if (StringUtils.isNotBlank(fidelizado.getCountryCode())) {
+            fidelizado.setCountryCode(fidelizado.getCountryCode().toUpperCase());
+        }
+
+        if (newCustomer.getContacts() != null) {
+            fidelizado.setContacts(modelMapper.map(newCustomer.getContacts(), new TypeToken<List<LoyalCustomerContactEntity>>() {
+            }.getType()));
+        }
+        if (newCustomer.getCollectives() != null) {
+            fidelizado.setCollectives(modelMapper.map(newCustomer.getCollectives(), new TypeToken<List<LoyalCustomerCollectiveDTO>>() {
+            }.getType()));
+        }
+        if (newCustomer.getTags() != null) {
+            fidelizado.setTags(fidelizadoEtiquetaBeanConverter.toEtiquetaBeanList(newCustomer.getTags()));
+        }
+        if (newCustomer.getCustomerLink() != null) {
+            fidelizado.setCustomerLink(modelMapper.map(newCustomer.getCustomerLink(), LoyalCustomerLinkEntity.class));
+        }
+        if (newCustomer.getNewCustomerAccess() != null) {
+            fidelizado.setAccess(modelMapper.map(newCustomer.getNewCustomerAccess(), LoyalCustomerAccessEntityDTO.class));
+        }
+        return fidelizado;
+    }
+}

--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersService.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersService.java
@@ -4,11 +4,14 @@ import com.comerzzia.api.core.service.exception.ApiException;
 import com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO;
 import com.comerzzia.api.loyalty.service.customers.LyCustomersService;
 import com.comerzzia.core.servicios.sesion.IDatosSesion;
+import com.comerzzia.unide.api.web.model.customer.AssociateCustomerRequest;
 import com.comerzzia.unide.api.web.model.customer.DeactivateCustomer;
 
 public interface UnideLyCustomersService extends LyCustomersService {
 
 	void deactivateLoyalCustomer(DeactivateCustomer deactivateModel, IDatosSesion datosSesion) throws ApiException;
 
-	LyCustomerDTO associateCustomer(LyCustomerDTO loyalCustomer, IDatosSesion datosSesion) throws ApiException;
+        LyCustomerDTO associateCustomer(LyCustomerDTO loyalCustomer, IDatosSesion datosSesion) throws ApiException;
+
+        LyCustomerDTO associateCustomer(AssociateCustomerRequest record, IDatosSesion datosSesion) throws ApiException;
 }

--- a/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
+++ b/src/main/java/com/comerzzia/unide/api/services/customers/UnideLyCustomersServiceImpl.java
@@ -43,6 +43,7 @@ import com.comerzzia.core.servicios.variables.VariableNotFoundException;
 import com.comerzzia.core.util.criptografia.CriptoException;
 import com.comerzzia.core.util.mybatis.exception.PersistenceExceptionFactory;
 import com.comerzzia.unide.api.web.model.customer.DeactivateCustomer;
+import com.comerzzia.unide.api.web.model.customer.AssociateCustomerRequest;
 
 @Service
 @Primary
@@ -56,6 +57,9 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
 	
     @Autowired
     private CollectiveMapper collectiveMapper;
+
+    @Autowired
+    private NewCustomerToFidelizadoConverter newCustomerToFidelizadoConverter;
 
 	@Override
 	public LyCustomerDTO insert(LyCustomerDTO loyalCustomer, IDatosSesion datosSesion)
@@ -131,7 +135,7 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
 		if(loyalCustomer == null) throw new NotFoundException();
 		
 		try {
-			log.debug("deactivateLoyalCustomer() - Dando de baja al fidelizado con ID " + loyalCustomer.getLyCustomerId());
+                        log.info("deactivateLoyalCustomer() - Dando de baja al fidelizado con ID " + loyalCustomer.getLyCustomerId());
 
 			loyalCustomer.setLastUpdate(new Date());
 			loyalCustomer.setDeactivationDate(new Date());
@@ -204,156 +208,180 @@ public class UnideLyCustomersServiceImpl extends LyCustomersServiceImpl implemen
 
         }
 
+        @Override
+        @Transactional(rollbackFor = Exception.class)
+        public LyCustomerDTO associateCustomer(AssociateCustomerRequest record, IDatosSesion datosSesion) throws ApiException {
+                LyCustomerDTO dto = newCustomerToFidelizadoConverter.convert(record);
+                List<CardEntity> cards = new ArrayList<>();
+                if (record.getCards() != null) {
+                        for (AssociateCustomerRequest.Card c : record.getCards()) {
+                                CardEntity card = new CardEntity();
+                                card.setCardNumber(c.getCardNumber());
+                                cards.add(card);
+                        }
+                }
+                dto.setCards(cards);
+                return associateCustomer(dto, datosSesion);
+        }
+
 		@Override
-		@Transactional(rollbackFor = Exception.class)
-		public LyCustomerDTO associateCustomer(LyCustomerDTO fidelizado, IDatosSesion datosSesion) throws ApiException {
-			if (fidelizado == null || fidelizado.getCards() == null || fidelizado.getCards().isEmpty() || StringUtils.isBlank(fidelizado.getCards().get(0).getCardNumber())) {
-				log.debug("associateCustomer - petición inválida: falta número de tarjeta");
-				throw new BadRequestException("El número de tarjeta es obligatorio");
-			}
-			String numeroTarjeta = fidelizado.getCards().get(0).getCardNumber();
-			log.debug("associateCustomer - iniciando para tarjeta " + numeroTarjeta);
+                @Transactional(rollbackFor = Exception.class)
+                public LyCustomerDTO associateCustomer(LyCustomerDTO fidelizado, IDatosSesion datosSesion) throws ApiException {
+                        validarPeticion(fidelizado);
+                        String numeroTarjeta = fidelizado.getCards().get(0).getCardNumber();
+                        Long idAnonimo = obtenerIdAnonimo(numeroTarjeta, datosSesion);
+                        LyCustomerDTO clienteAnonimo = selectDTOByPrimaryKey(idAnonimo, datosSesion);
+                        comprobarClienteAnonimo(clienteAnonimo);
+                        validarDuplicados(fidelizado, datosSesion, idAnonimo);
+                        asignarColectivoRegistro(fidelizado, datosSesion);
+                        normalizarUsuarioAcceso(fidelizado);
+                        actualizarDatosPrincipales(fidelizado, clienteAnonimo, datosSesion);
+                        reemplazarContactos(fidelizado, idAnonimo, datosSesion);
+                        actualizarInfoComplementaria(fidelizado, idAnonimo, datosSesion);
 
-			CardDTO tarjetaDto;
-			try {
-				tarjetaDto = cardsService.selectByCardNumber(numeroTarjeta, datosSesion);
-			}
-			catch (NotFoundException e) {
-				log.debug("associateCustomer - tarjeta no encontrada: " + numeroTarjeta);
-				throw new NotFoundException();
-			}
-			Long idAnonimo = tarjetaDto.getLyCustomer() != null ? tarjetaDto.getLyCustomer().getLyCustomerId() : null;
-			if (idAnonimo == null) {
-				log.debug("associateCustomer - tarjeta " + numeroTarjeta + " sin cliente asociado");
-				throw new NotFoundException();
-			}
-			log.debug("associateCustomer - cliente anónimo encontrado: id " + idAnonimo);
+                        fidVersionControlService.checkLoyalCustomersVersion(datosSesion, new LoyalCustomerVersion(idAnonimo));
+                        log.info("associateCustomer - finalizado para cliente " + idAnonimo);
 
-			// Verificar que aún no tiene dni o documento
-			LyCustomerDTO clienteAnonimo = selectDTOByPrimaryKey(idAnonimo, datosSesion);
-			if (StringUtils.isNotBlank(clienteAnonimo.getVatNumber())) {
-				log.debug("associateCustomer - cliente " + idAnonimo + " ya tiene documento " + clienteAnonimo.getVatNumber());
-				throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "Esta tarjeta ya tiene un fidelizado con datos asociado");
-			}
+                        return fidelizado;
+                }
 
-			if (StringUtils.isNotBlank(fidelizado.getVatNumber())) {
-				LyCustomerExample ejemploDni = new LyCustomerExample();
-				ejemploDni.or().andInstanceUidEqualTo(datosSesion.getUidInstancia()).andVatNumberEqualTo(fidelizado.getVatNumber()).andLyCustomerIdNotEqualTo(idAnonimo);
-				List<LyCustomerDTO> clientesConDni = mapper.selectFromViewByExample(ejemploDni);
-				if (!clientesConDni.isEmpty()) {
-					log.debug("associateCustomer - VAT duplicado " + fidelizado.getVatNumber() + " para cliente " + idAnonimo);
-					throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "El documento indicado ya se encuentra registrado en el sistema");
-				}
-			}
+                private void validarPeticion(LyCustomerDTO fidelizado) {
+                        if (fidelizado == null || fidelizado.getCards() == null || fidelizado.getCards().isEmpty() || StringUtils.isBlank(fidelizado.getCards().get(0).getCardNumber())) {
+                                log.info("associateCustomer - petición inválida: falta número de tarjeta");
+                                throw new BadRequestException("El número de tarjeta es obligatorio");
+                        }
+                }
 
-			if (!CollectionUtils.isEmpty(fidelizado.getContacts())) {
-				for (LoyalCustomerContactEntity contactoNuevo : fidelizado.getContacts()) {
-					LoyalCustomerContactExample ejemploContacto = new LoyalCustomerContactExample();
-					ejemploContacto.or().andInstanceUidEqualTo(datosSesion.getUidInstancia()).andContactTypeCodeEqualTo(contactoNuevo.getContactTypeCode()).andValueEqualTo(contactoNuevo.getValue())
-					        .andLoyalCustomerIdNotEqualTo(idAnonimo);
-					List<LoyalCustomerContactEntity> contactosExistentes = mapperContact.selectByExample(ejemploContacto);
-					if (!contactosExistentes.isEmpty()) {
-						String tipo = "EMAIL".equals(contactoNuevo.getContactTypeCode()) ? "E-mail" : contactoNuevo.getContactTypeCode().startsWith("MOVIL") ? "Móvil" : "Teléfono";
-						log.debug("associateCustomer - " + tipo + " duplicado " + contactoNuevo.getValue() + " para cliente " + idAnonimo);
-						throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "El " + tipo + " indicado ya se encuentra registrado en el sistema");
-					}
-				}
-			}
+                private Long obtenerIdAnonimo(String numeroTarjeta, IDatosSesion datosSesion) throws ApiException {
+                        log.info("associateCustomer - iniciando para tarjeta " + numeroTarjeta);
+                        try {
+                                CardDTO tarjetaDto = cardsService.selectByCardNumber(numeroTarjeta, datosSesion);
+                                Long idAnonimo = tarjetaDto.getLyCustomer() != null ? tarjetaDto.getLyCustomer().getLyCustomerId() : null;
+                                if (idAnonimo == null) {
+                                        log.info("associateCustomer - tarjeta " + numeroTarjeta + " sin cliente asociado");
+                                        throw new NotFoundException();
+                                }
+                                return idAnonimo;
+                        } catch (NotFoundException e) {
+                                log.info("associateCustomer - tarjeta no encontrada: " + numeroTarjeta);
+                                throw new NotFoundException();
+                        }
+                }
 
-			// Añadir colectivo REG automáticamente
-			try {
-				String codigoColectivo = variablesService.consultarValor(datosSesion, COD_COLECTIVO_REGISTRO);
-				if (StringUtils.isNotBlank(codigoColectivo)) {
-					CollectiveKey claveColectivo = new CollectiveKey();
-					claveColectivo.setUidInstancia(datosSesion.getUidInstancia());
-					claveColectivo.setCodColectivo(codigoColectivo);
-					com.comerzzia.api.loyalty.persistence.collectives.Collective maestro = collectiveMapper.selectByPrimaryKey(claveColectivo);
-					LoyalCustomerCollectiveDTO colectivoRegistro = new LoyalCustomerCollectiveDTO();
-					colectivoRegistro.setCollectiveCode(codigoColectivo);
-					colectivoRegistro.setCollectiveDes(maestro != null ? maestro.getDesColectivo() : null);
-					fidelizado.setCollectives(Collections.singletonList(colectivoRegistro));
-					log.debug("associateCustomer - colectivo REG añadido: " + codigoColectivo);
-				}
-			}
-			catch (VariableException | VariableNotFoundException ignored) {
-				log.debug("associateCustomer - variable COD_COLECTIVO_REGISTRO no encontrada");
-			}
+                private void comprobarClienteAnonimo(LyCustomerDTO clienteAnonimo) throws ApiException {
+                        if (StringUtils.isNotBlank(clienteAnonimo.getVatNumber())) {
+                                log.info("associateCustomer - la tarjeta ya tiene asignado el documento " + clienteAnonimo.getVatNumber());
+                                throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "Esta tarjeta ya tiene un fidelizado con datos asociado");
+                        }
+                        log.info("associateCustomer - fidelizado anónimo localizado: id " + clienteAnonimo.getLyCustomerId());
+                }
 
-			if (fidelizado.getAccess() != null && StringUtils.isNotBlank(fidelizado.getAccess().getUser())) {
-				String usuarioBruto = fidelizado.getAccess().getUser();
-				String usuarioLimpio = usuarioBruto.replace("_", "").replace("@", "");
-				fidelizado.getAccess().setUser(usuarioLimpio);
-				log.debug("associateCustomer - usuario limpiado de '" + usuarioBruto + "' a '" + usuarioLimpio + "'");
-			}
+                private void validarDuplicados(LyCustomerDTO fidelizado, IDatosSesion datosSesion, Long idAnonimo) throws ApiException {
+                        if (StringUtils.isNotBlank(fidelizado.getVatNumber())) {
+                                LyCustomerExample ejemploDni = new LyCustomerExample();
+                                ejemploDni.or().andInstanceUidEqualTo(datosSesion.getUidInstancia()).andVatNumberEqualTo(fidelizado.getVatNumber()).andLyCustomerIdNotEqualTo(idAnonimo);
+                                List<LyCustomerDTO> clientesConDni = mapper.selectFromViewByExample(ejemploDni);
+                                if (!clientesConDni.isEmpty()) {
+                                        log.info("associateCustomer - VAT duplicado " + fidelizado.getVatNumber() + " para cliente " + idAnonimo);
+                                        throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "El documento indicado ya se encuentra registrado en el sistema");
+                                }
+                        }
 
-			fidelizado.setLyCustomerId(clienteAnonimo.getLyCustomerId());
-			fidelizado.setLyCustomerCode(clienteAnonimo.getLyCustomerCode());
-			log.debug("associateCustomer - asignando datos al cliente " + idAnonimo);
+                        if (!CollectionUtils.isEmpty(fidelizado.getContacts())) {
+                                for (LoyalCustomerContactEntity contactoNuevo : fidelizado.getContacts()) {
+                                        LoyalCustomerContactExample ejemploContacto = new LoyalCustomerContactExample();
+                                        ejemploContacto.or().andInstanceUidEqualTo(datosSesion.getUidInstancia()).andContactTypeCodeEqualTo(contactoNuevo.getContactTypeCode()).andValueEqualTo(contactoNuevo.getValue())
+                                                        .andLoyalCustomerIdNotEqualTo(idAnonimo);
+                                        List<LoyalCustomerContactEntity> contactosExistentes = mapperContact.selectByExample(ejemploContacto);
+                                        if (!contactosExistentes.isEmpty()) {
+                                                String tipo = "EMAIL".equals(contactoNuevo.getContactTypeCode()) ? "E-mail" : contactoNuevo.getContactTypeCode().startsWith("MOVIL") ? "Móvil" : "Teléfono";
+                                                log.info("associateCustomer - " + tipo + " duplicado " + contactoNuevo.getValue() + " para cliente " + idAnonimo);
+                                                throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "El " + tipo + " indicado ya se encuentra registrado en el sistema");
+                                        }
+                                }
+                        }
+                }
 
-			super.update(modelMapper.map(fidelizado, LyCustomerEntity.class), datosSesion);
-			log.debug("associateCustomer - datos principales actualizados para cliente " + idAnonimo);
+                private void asignarColectivoRegistro(LyCustomerDTO fidelizado, IDatosSesion datosSesion) {
+                        try {
+                                String codigoColectivo = variablesService.consultarValor(datosSesion, COD_COLECTIVO_REGISTRO);
+                                if (StringUtils.isNotBlank(codigoColectivo)) {
+                                        CollectiveKey claveColectivo = new CollectiveKey();
+                                        claveColectivo.setUidInstancia(datosSesion.getUidInstancia());
+                                        claveColectivo.setCodColectivo(codigoColectivo);
+                                        com.comerzzia.api.loyalty.persistence.collectives.Collective maestro = collectiveMapper.selectByPrimaryKey(claveColectivo);
+                                        LoyalCustomerCollectiveDTO colectivoRegistro = new LoyalCustomerCollectiveDTO();
+                                        colectivoRegistro.setCollectiveCode(codigoColectivo);
+                                        colectivoRegistro.setCollectiveDes(maestro != null ? maestro.getDesColectivo() : null);
+                                        fidelizado.setCollectives(Collections.singletonList(colectivoRegistro));
+                                        log.info("associateCustomer - colectivo REG añadido: " + codigoColectivo);
+                                }
+                        } catch (VariableException | VariableNotFoundException ignored) {
+                                log.info("associateCustomer - variable COD_COLECTIVO_REGISTRO no encontrada");
+                        }
+                }
 
-			CardUK claveTarjeta = new CardUK(datosSesion, numeroTarjeta);
-			CardEntity entidadTarjeta;
-			try {
-				entidadTarjeta = cardsService.selectByUniqueKey(datosSesion, claveTarjeta);
-			}
-			catch (NotFoundException e) {
-				log.debug("associateCustomer - tarjeta " + numeroTarjeta + " no encontrada en clave única");
-				throw new ApiException(ApiException.STATUS_RESPONSE_ERROR_CONFLICT_STATE, "No se encontró la tarjeta para asignar");
-			}
-			entidadTarjeta.setLyCustomerId(idAnonimo);
-			cardsService.updateByPrimaryKey(datosSesion, entidadTarjeta);
-			log.debug("associateCustomer - tarjeta " + numeroTarjeta + " asignada a cliente " + idAnonimo);
+                private void normalizarUsuarioAcceso(LyCustomerDTO fidelizado) {
+                        if (fidelizado.getAccess() != null && StringUtils.isNotBlank(fidelizado.getAccess().getUser())) {
+                                String usuarioBruto = fidelizado.getAccess().getUser();
+                                String usuarioLimpio = usuarioBruto.replace("_", "").replace("@", "");
+                                fidelizado.getAccess().setUser(usuarioLimpio);
+                                log.info("associateCustomer - usuario limpiado de '" + usuarioBruto + "' a '" + usuarioLimpio + "'");
+                        }
+                }
 
-			LoyalCustomerContactExample ejemploBorrar = new LoyalCustomerContactExample();
-			ejemploBorrar.or().andInstanceUidEqualTo(datosSesion.getUidInstancia()).andLoyalCustomerIdEqualTo(idAnonimo);
-			mapperContact.deleteByExample(ejemploBorrar);
-			log.debug("associateCustomer - contactos antiguos borrados para cliente " + idAnonimo);
+                private void actualizarDatosPrincipales(LyCustomerDTO fidelizado, LyCustomerDTO clienteAnonimo, IDatosSesion datosSesion) throws ApiException {
+                        fidelizado.setLyCustomerId(clienteAnonimo.getLyCustomerId());
+                        fidelizado.setLyCustomerCode(clienteAnonimo.getLyCustomerCode());
+                        log.info("associateCustomer - asignando datos al cliente " + clienteAnonimo.getLyCustomerId());
+                        super.update(modelMapper.map(fidelizado, LyCustomerEntity.class), datosSesion);
+                        log.info("associateCustomer - datos principales actualizados para cliente " + clienteAnonimo.getLyCustomerId());
+                }
 
-			if (!CollectionUtils.isEmpty(fidelizado.getContacts())) {
-				for (LoyalCustomerContactEntity contactoInsertar : fidelizado.getContacts()) {
-					contactoInsertar.setInstanceUid(datosSesion.getUidInstancia());
-					contactoInsertar.setLoyalCustomerId(idAnonimo);
-					contactsService.insert(contactoInsertar, datosSesion);
-				}
-				log.debug("associateCustomer - " + fidelizado.getContacts().size() + " contactos nuevos insertados para cliente " + idAnonimo);
-			}
+                private void reemplazarContactos(LyCustomerDTO fidelizado, Long idAnonimo, IDatosSesion datosSesion) throws ApiException {
+                        LoyalCustomerContactExample ejemploBorrar = new LoyalCustomerContactExample();
+                        ejemploBorrar.or().andInstanceUidEqualTo(datosSesion.getUidInstancia()).andLoyalCustomerIdEqualTo(idAnonimo);
+                        mapperContact.deleteByExample(ejemploBorrar);
+                        log.info("associateCustomer - contactos antiguos borrados para cliente " + idAnonimo);
 
-			if (fidelizado.getAccess() != null) {
-				LoyalCustomerAccessEntityDTO acceso = fidelizado.getAccess();
-				acceso.setLoyalCustomerId(idAnonimo);
-				try {
-					accessService.selectByLoyalCustomer(datosSesion, idAnonimo);
-					accessService.updateCustomerAccessData(datosSesion, acceso);
-					log.debug("associateCustomer - datos de acceso actualizados para cliente " + idAnonimo);
-				}
-				catch (NotFoundException nf) {
-					accessService.insert(acceso, datosSesion);
-					log.debug("associateCustomer - acceso insertado para cliente " + idAnonimo);
-				}
-			}
+                        if (!CollectionUtils.isEmpty(fidelizado.getContacts())) {
+                                for (LoyalCustomerContactEntity contactoInsertar : fidelizado.getContacts()) {
+                                        contactoInsertar.setInstanceUid(datosSesion.getUidInstancia());
+                                        contactoInsertar.setLoyalCustomerId(idAnonimo);
+                                        contactsService.insert(contactoInsertar, datosSesion);
+                                }
+                                log.info("associateCustomer - " + fidelizado.getContacts().size() + " contactos nuevos insertados para cliente " + idAnonimo);
+                        }
+                }
 
-			if (!CollectionUtils.isEmpty(fidelizado.getCollectives())) {
-				for (LoyalCustomerCollectiveDTO colec : fidelizado.getCollectives()) {
-					colec.setLoyalCustomerId(idAnonimo);
-					collectivesService.insert(colec, datosSesion);
-				}
-				log.debug("associateCustomer - " + fidelizado.getCollectives().size() + " colectivos insertados para cliente " + idAnonimo);
-			}
+                private void actualizarInfoComplementaria(LyCustomerDTO fidelizado, Long idAnonimo, IDatosSesion datosSesion) throws ApiException {
+                        if (fidelizado.getAccess() != null) {
+                                LoyalCustomerAccessEntityDTO acceso = fidelizado.getAccess();
+                                acceso.setLoyalCustomerId(idAnonimo);
+                                try {
+                                        accessService.selectByLoyalCustomer(datosSesion, idAnonimo);
+                                        accessService.updateCustomerAccessData(datosSesion, acceso);
+                                        log.info("associateCustomer - datos de acceso actualizados para cliente " + idAnonimo);
+                                } catch (NotFoundException nf) {
+                                        accessService.insert(acceso, datosSesion);
+                                        log.info("associateCustomer - acceso insertado para cliente " + idAnonimo);
+                                }
+                        }
 
-			if (!CollectionUtils.isEmpty(fidelizado.getTags())) {
-				for (EtiquetaBean etiqueta : fidelizado.getTags()) {
-					etiqueta.setIdObjetoEtiquetaEnlazada(idAnonimo.toString());
-					etiqueta.setIdClaseEtiquetaEnlazada(CustomerTagsResource.CLASS_ID);
-					customerTagsService.insertTagLink(etiqueta, datosSesion);
-				}
-				log.debug("associateCustomer - " + fidelizado.getTags().size() + " etiquetas insertadas para cliente " + idAnonimo);
-			}
+                        if (!CollectionUtils.isEmpty(fidelizado.getCollectives())) {
+                                for (LoyalCustomerCollectiveDTO colec : fidelizado.getCollectives()) {
+                                        colec.setLoyalCustomerId(idAnonimo);
+                                        collectivesService.insert(colec, datosSesion);
+                                }
+                                log.info("associateCustomer - " + fidelizado.getCollectives().size() + " colectivos insertados para cliente " + idAnonimo);
+                        }
 
-			fidVersionControlService.checkLoyalCustomersVersion(datosSesion, new LoyalCustomerVersion(idAnonimo));
-			log.debug("associateCustomer - finalizado para cliente " + idAnonimo);
-
-			return fidelizado;
-		}
-	}
+                        if (!CollectionUtils.isEmpty(fidelizado.getTags())) {
+                                for (EtiquetaBean etiqueta : fidelizado.getTags()) {
+                                        etiqueta.setIdObjetoEtiquetaEnlazada(idAnonimo.toString());
+                                        etiqueta.setIdClaseEtiquetaEnlazada(CustomerTagsResource.CLASS_ID);
+                                        customerTagsService.insertTagLink(etiqueta, datosSesion);
+                                }
+                                log.info("associateCustomer - " + fidelizado.getTags().size() + " etiquetas insertadas para cliente " + idAnonimo);
+                        }
+                }	}

--- a/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
+++ b/src/main/java/com/comerzzia/unide/api/web/rest/customers/UnideCustomersResource.java
@@ -1,38 +1,23 @@
 package com.comerzzia.unide.api.web.rest.customers;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.annotation.Resource;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.commons.lang.StringUtils;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
 import com.comerzzia.api.core.service.exception.ApiException;
 import com.comerzzia.api.core.service.util.ComerzziaDatosSesion;
-import com.comerzzia.api.loyalty.persistence.cards.CardEntity;
 import com.comerzzia.api.loyalty.persistence.customers.LyCustomerDTO;
-import com.comerzzia.api.loyalty.persistence.customers.access.LoyalCustomerAccessEntityDTO;
-import com.comerzzia.api.loyalty.persistence.customers.collectives.LoyalCustomerCollectiveDTO;
-import com.comerzzia.api.loyalty.persistence.customers.contacttypes.LoyalCustomerContactEntity;
-import com.comerzzia.api.loyalty.persistence.customers.links.LoyalCustomerLinkEntity;
-import com.comerzzia.api.loyalty.web.model.customer.NewCustomer;
-import javax.ws.rs.BadRequestException;
-import com.comerzzia.api.loyalty.web.model.customertag.FidelizadoEtiquetaBeanConverter;
 import com.comerzzia.unide.api.services.customers.UnideLyCustomersService;
 import com.comerzzia.unide.api.web.model.customer.AssociateCustomerRequest;
 import com.comerzzia.unide.api.web.model.customer.DeactivateCustomer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -46,11 +31,6 @@ public class UnideCustomersResource {
 	@Resource(name = "datosSesionRequest")
 	protected ComerzziaDatosSesion datosSesionRequest;
 
-	@Autowired
-	protected ModelMapper modelMapper;
-	
-	@Autowired
-	protected FidelizadoEtiquetaBeanConverter fidelizadoEtiquetaBeanConverter;
 	
 	@Autowired
 	protected UnideLyCustomersService service;
@@ -69,73 +49,17 @@ public class UnideCustomersResource {
 		}
 	}
 	
-	@PUT
-	@Path("/associateCustomer")
-	public LyCustomerDTO associateCustomer(@Valid AssociateCustomerRequest record) throws ApiException {
-		// 1) Validación de tarjeta obligatoria
-		if (record.getCards() == null || record.getCards().isEmpty() || StringUtils.isBlank(record.getCards().get(0).getCardNumber())) {
-			throw new BadRequestException("Card number is mandatory");
-		}
-
-		try {
-			// 2) Mappea el JSON a tu DTO de persistencia
-			LyCustomerDTO dto = mapNewCustomerToFidelizadoBean(record);
-
-			// 3) Mapea el acceso si viene
-			if (record.getNewCustomerAccess() != null) {
-				ObjectMapper mapper = new ObjectMapper();
-				LoyalCustomerAccessEntityDTO access = mapper.convertValue(record.getNewCustomerAccess(), LoyalCustomerAccessEntityDTO.class);
-				dto.setAccess(access);
-			}
-
-			// 4) Añade la lista de tarjetas (sólo la primera, obligatoria)
-			List<CardEntity> cards = new ArrayList<>();
-			for (AssociateCustomerRequest.Card c : record.getCards()) {
-				CardEntity card = new CardEntity();
-				card.setCardNumber(c.getCardNumber());
-				cards.add(card);
-			}
-			dto.setCards(cards);
-
-			// 5) Llama al servicio transaccional
-			return service.associateCustomer(dto, datosSesionRequest.getDatosSesionBean());
-		}
-		catch (ApiException e) {
-			throw e;
-		}
-		catch (Exception e) {
-			throw new ApiException(e.getMessage(), e);
-		}
-	}
-
-	public LyCustomerDTO mapNewCustomerToFidelizadoBean(NewCustomer newCustomer) {
-		LyCustomerDTO fidelizado = modelMapper.map(newCustomer, LyCustomerDTO.class);
-
-		if (StringUtils.isNotBlank(fidelizado.getCountryCode())) {
-			fidelizado.setCountryCode(fidelizado.getCountryCode().toUpperCase());
-		}
-
-		if (newCustomer.getContacts() != null) {
-			modelMapper.map(newCustomer.getContacts(), new TypeToken<List<LoyalCustomerContactEntity>>(){
-			}.getType());
-			fidelizado.setContacts(modelMapper.map(newCustomer.getContacts(), new TypeToken<List<LoyalCustomerContactEntity>>(){
-			}.getType()));
-		}
-		if (newCustomer.getCollectives() != null) {
-
-			fidelizado.setCollectives(modelMapper.map(newCustomer.getCollectives(), new TypeToken<List<LoyalCustomerCollectiveDTO>>(){
-			}.getType()));
-		}
-		if (newCustomer.getTags() != null) {
-			fidelizado.setTags(fidelizadoEtiquetaBeanConverter.toEtiquetaBeanList(newCustomer.getTags()));
-		}
-		if (newCustomer.getCustomerLink() != null) {
-			fidelizado.setCustomerLink(modelMapper.map(newCustomer.getCustomerLink(), LoyalCustomerLinkEntity.class));
-		}
-
-		if (newCustomer.getNewCustomerAccess() != null) {
-			fidelizado.setAccess(modelMapper.map(newCustomer.getNewCustomerAccess(), LoyalCustomerAccessEntityDTO.class));
-		}
-		return fidelizado;
-	}
+        @PUT
+        @Path("/associateCustomer")
+        public LyCustomerDTO associateCustomer(@Valid AssociateCustomerRequest record) throws ApiException {
+                try {
+                        return service.associateCustomer(record, datosSesionRequest.getDatosSesionBean());
+                }
+                catch (ApiException e) {
+                        throw e;
+                }
+                catch (Exception e) {
+                        throw new ApiException(e.getMessage(), e);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- move customer conversion to `NewCustomerToFidelizadoConverter`
- move association logic to service layer and simplify controller
- split `associateCustomer` method into smaller helpers and improve logs
- adjust logging level when deactivating customer

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e12255354832bb82c2eb31e376611