### PR TITLE
Load Comerzzia report templates from bundled resources

### DIFF
--- a/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/documentprint/AbstractDocumentPrintService.java
+++ b/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/documentprint/AbstractDocumentPrintService.java
@@ -172,24 +172,43 @@ public abstract class AbstractDocumentPrintService {
 
 	abstract protected String getTemplateExtension();
 
-	protected File getTemplateLocaleFile(String template, String localeId) {
-		String partialFileName = AppInfo.getInformesInfo().getRutaBase() + TEMPLATES_PATH + template;
+        protected File getTemplateLocaleFile(String template, String localeId) {
+                String basePath = AppInfo.getInformesInfo().getRutaBase();
+                if (StringUtils.isBlank(basePath)) {
+                        basePath = "";
+                }
+                if (!basePath.endsWith(File.separator)) {
+                        basePath = basePath + File.separator;
+                }
 
-		// by localeId
-		File result = new File(partialFileName + "_" + localeId.toLowerCase() + getTemplateExtension());
+                File result = buildTemplateCandidate(basePath + TEMPLATES_PATH + template, localeId);
 
-		// by country
-		if (!result.exists()) {
-			result = new File(partialFileName + "_" + StringUtils.left(localeId.toLowerCase(), 2) + getTemplateExtension());
-		}
+                if (!result.exists()) {
+                        String normalizedTemplate = template.replace('.', File.separatorChar);
+                        result = buildTemplateCandidate(basePath + normalizedTemplate, localeId);
+                }
 
-		// by name
-		if (!result.exists()) {
-			result = new File(partialFileName + getTemplateExtension());
-		}
+                return result;
+        }
 
-		return result;
-	}
+        private File buildTemplateCandidate(String partialFileName, String localeId) {
+                String locale = localeId != null ? localeId.toLowerCase() : null;
+                String extension = getTemplateExtension();
+                File result = null;
+
+                if (StringUtils.isNotBlank(locale)) {
+                        result = new File(partialFileName + "_" + locale + extension);
+                        if (!result.exists() && locale.length() >= 2) {
+                                result = new File(partialFileName + "_" + StringUtils.left(locale, 2) + extension);
+                        }
+                }
+
+                if (result == null || !result.exists()) {
+                        result = new File(partialFileName + extension);
+                }
+
+                return result;
+        }
 
 	protected File getTemplate(PrintDocumentDTO printRequest, Map<String, Object> docParameters) throws ApiException {
 		String templateExtension = getTemplateExtension();

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/BricodepotApplication.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/BricodepotApplication.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.comerzzia.bricodepot.api.omnichannel.api.config.InformesResourceInitializer;
+
 // Esta configuracion elimina el control de errores por defecto de spring mvc
 // que provocaba que por ejemplo un 401 (Unauthorized) se devolvia como un 404. 
 // Esto se debe a que una aplicacion web tendria que redirigir a la pagina que 
@@ -24,7 +26,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 public class BricodepotApplication extends SpringBootServletInitializer {
 
-        public static void main(String[] args) {
+	public static void main(String[] args) {
+                InformesResourceInitializer.initialize();
                 SpringApplication.run(BricodepotApplication.class, args);
         }
 

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/InformesResourceConfigurer.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/InformesResourceConfigurer.java
@@ -1,0 +1,27 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.config;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Re-applies the resolved report directory once the Spring context is ready so
+ * that late initialising components within the Comerzzia stack see the
+ * expected configuration.
+ */
+@Component
+public class InformesResourceConfigurer {
+
+    private static final Logger log = LoggerFactory.getLogger(InformesResourceConfigurer.class);
+
+    @PostConstruct
+    public void configure() {
+        try {
+            InformesResourceInitializer.applyRutaBase();
+        } catch (Exception ex) {
+            log.warn("Unable to propagate Comerzzia report directory: {}", ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/InformesResourceInitializer.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/InformesResourceInitializer.java
@@ -1,0 +1,192 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import com.comerzzia.core.util.config.AppInfo;
+
+/**
+ * Resolves the location of the bundled report templates so that Comerzzia's
+ * legacy components can find them on the filesystem. The initializer inspects
+ * the classpath for the {@code informes} directory and, when required, copies
+ * the resources to a temporary location that behaves like the expected
+ * {@code COMERZZIA_HOME/informes} directory.
+ */
+public final class InformesResourceInitializer {
+
+    private static final Logger log = LoggerFactory.getLogger(InformesResourceInitializer.class);
+
+    private static final String COMERZZIA_HOME_PROPERTY = "COMERZZIA_HOME";
+    private static final String INFORMES_DIRECTORY = "informes";
+    private static final String CLASSPATH_PATTERN = "classpath*:/informes/**/*.*";
+
+    private static volatile Path informesDirectory;
+
+    private InformesResourceInitializer() {
+        // Utility class
+    }
+
+    /**
+     * Ensures that the report directory is available on the filesystem and that
+     * {@link AppInfo} is aware of its location.
+     */
+    public static synchronized void initialize() {
+        if (informesDirectory == null) {
+            informesDirectory = resolveInformesDirectory();
+            if (informesDirectory == null) {
+                log.warn("Unable to resolve Comerzzia report directory from classpath resources");
+                return;
+            }
+        }
+
+        applyRutaBase();
+    }
+
+    /**
+     * Applies the resolved directory to the Comerzzia configuration if possible.
+     */
+    public static synchronized void applyRutaBase() {
+        if (informesDirectory == null) {
+            return;
+        }
+
+        String base = informesDirectory.toAbsolutePath().toString();
+        if (!base.endsWith(File.separator)) {
+            base = base + File.separator;
+        }
+
+        try {
+            Object informesInfo = AppInfo.getInformesInfo();
+            if (informesInfo != null) {
+                Method setter = informesInfo.getClass().getMethod("setRutaBase", String.class);
+                setter.invoke(informesInfo, base);
+                log.debug("Comerzzia report base directory set to {}", base);
+            }
+        } catch (NoSuchMethodException e) {
+            log.warn("Comerzzia InformesInfo does not expose a setRutaBase method");
+        } catch (Exception e) {
+            log.warn("Unable to configure Comerzzia report directory: {}", e.getMessage());
+        }
+    }
+
+    private static Path resolveInformesDirectory() {
+        try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            URL resourceUrl = classLoader.getResource(INFORMES_DIRECTORY);
+            if (resourceUrl != null) {
+                Path resolved = resolveFromUrl(resourceUrl);
+                if (resolved != null) {
+                    ensureComerzziaHome(resolved.getParent());
+                    return resolved;
+                }
+            }
+        } catch (Exception ex) {
+            log.debug("Failed to resolve report directory from classpath: {}", ex.getMessage());
+        }
+
+        Path projectPath = Paths.get("src", "main", "resources", INFORMES_DIRECTORY);
+        if (Files.exists(projectPath)) {
+            Path absolute = projectPath.toAbsolutePath();
+            ensureComerzziaHome(absolute.getParent());
+            return absolute;
+        }
+
+        return null;
+    }
+
+    private static Path resolveFromUrl(URL resourceUrl) throws IOException, URISyntaxException {
+        if (StringUtils.equals(resourceUrl.getProtocol(), "file")) {
+            URI uri = resourceUrl.toURI();
+            Path path = Paths.get(uri);
+            if (Files.isDirectory(path)) {
+                return path;
+            }
+        }
+
+        if (StringUtils.equals(resourceUrl.getProtocol(), "jar")) {
+            Path tempHome = Files.createTempDirectory("comerzzia-home");
+            Path informesPath = tempHome.resolve(INFORMES_DIRECTORY);
+            copyClasspathResources(informesPath);
+            ensureComerzziaHome(tempHome);
+            return informesPath;
+        }
+
+        // Attempt with Spring's ClassPathResource as a fallback
+        ClassPathResource classPathResource = new ClassPathResource(INFORMES_DIRECTORY);
+        if (classPathResource.exists() && classPathResource.isFile()) {
+            try {
+                Path path = classPathResource.getFile().toPath();
+                if (Files.isDirectory(path)) {
+                    return path;
+                }
+            } catch (IOException ex) {
+                log.debug("Unable to access classpath resource as file: {}", ex.getMessage());
+            }
+        }
+
+        return null;
+    }
+
+    private static void copyClasspathResources(Path targetDirectory) throws IOException {
+        Files.createDirectories(targetDirectory);
+
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        Resource[] resources = resolver.getResources(CLASSPATH_PATTERN);
+
+        String marker = "/" + INFORMES_DIRECTORY + "/";
+
+        for (Resource resource : resources) {
+            if (!resource.isReadable() || resource.getFilename() == null) {
+                continue;
+            }
+
+            String resourcePath = resource.getURL().toString();
+            int idx = resourcePath.indexOf(marker);
+            if (idx < 0) {
+                continue;
+            }
+
+            String relative = resourcePath.substring(idx + marker.length());
+            relative = relative.replace('/', File.separatorChar);
+
+            Path destination = targetDirectory.resolve(relative);
+            Path parent = destination.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+
+            try (InputStream inputStream = resource.getInputStream()) {
+                Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+
+    private static void ensureComerzziaHome(Path homeDirectory) {
+        if (homeDirectory == null) {
+            return;
+        }
+
+        if (StringUtils.isNotBlank(System.getProperty(COMERZZIA_HOME_PROPERTY))
+                || StringUtils.isNotBlank(System.getenv(COMERZZIA_HOME_PROPERTY))) {
+            return;
+        }
+
+        System.setProperty(COMERZZIA_HOME_PROPERTY, homeDirectory.toAbsolutePath().toString());
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/facturas/SalesDocumentPrintServiceImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/facturas/SalesDocumentPrintServiceImpl.java
@@ -177,6 +177,9 @@ public class SalesDocumentPrintServiceImpl implements SalesDocumentPrintService 
         }
 
         Locale locale = metadata.getLocale() != null ? metadata.getLocale() : datosSesion.getLocale();
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
         printDocumentDTO.setMimeType("application/pdf");
         printDocumentDTO.setPrintTemplate(resolvedTemplate);
         printDocumentDTO.setOutputDocumentName(resolveDocumentName(request, documentUid));
@@ -192,6 +195,7 @@ public class SalesDocumentPrintServiceImpl implements SalesDocumentPrintService 
         }
         printDocumentDTO.getCustomParams().put(DocumentPrintService.PARAM_COMPANY_CODE, companyCode);
         printDocumentDTO.getCustomParams().put(DocumentPrintService.PARAM_LOCALE, locale);
+        printDocumentDTO.getCustomParams().put(DocumentPrintService.PARAM_LOCALE_ID, locale.getLanguage());
         printDocumentDTO.getCustomParams().put(DocumentPrintService.PARAM_DEFAULT_TEMPLATE, TEMPLATE_NAME);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary
- replace the Comerzzia home initializer with a resource-driven resolver that exposes the bundled `informes` directory on the filesystem and updates AppInfo
- add a Spring component that reapplies the resolved report base path after the context has started
- fall back to the real report folder when locating templates so personalised Jasper files under `informes/ventas/facturas` are found without doctemplate copies

## Testing
- `mvn -q -DskipTests package` *(fails: missing proprietary com.comerzzia SNAPSHOT dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f89f25e4d4832ba54bc2c8d563be7e