### PR TITLE
Add base64 PDF sales document print endpoint customization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>com.comerzzia.omnichannel</groupId>
-			<artifactId>comerzzia-omnichannel-services</artifactId>
-			<version>4.8.1.230717</version>
-		</dependency>
+                <dependency>
+                        <groupId>com.comerzzia.omnichannel</groupId>
+                        <artifactId>comerzzia-omnichannel-services</artifactId>
+                        <version>4.8-SNAPSHOT</version>
+                </dependency>
 		<dependency>
 			<groupId>com.comerzzia.api.v2.core</groupId>
 			<artifactId>comerzzia-api-core-services</artifactId>

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/BricodepotApplication.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/BricodepotApplication.java
@@ -1,0 +1,36 @@
+package com.comerzzia.bricodepot.api.omnichannel.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+// Esta configuracion elimina el control de errores por defecto de spring mvc
+// que provocaba que por ejemplo un 401 (Unauthorized) se devolvia como un 404. 
+// Esto se debe a que una aplicacion web tendria que redirigir a la pagina que 
+// controlara esa situacion. Esto no procede en una aplicacion que solo maneja REST
+@EnableAutoConfiguration(exclude = {ErrorMvcAutoConfiguration.class})
+@ImportResource({"classpath*:comerzzia-*context.xml"})
+@SpringBootApplication
+@EnableCaching
+@EnableScheduling
+@EnableTransactionManagement
+
+public class BricodepotApplication extends SpringBootServletInitializer {
+
+        public static void main(String[] args) {
+                SpringApplication.run(BricodepotApplication.class, args);
+        }
+
+        @Override
+        protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+                return application.sources(BricodepotApplication.class);
+        }
+
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/BricodepotInformesConfiguration.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/BricodepotInformesConfiguration.java
@@ -1,0 +1,54 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.config;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+
+import com.comerzzia.core.util.config.AppInfo;
+
+@Configuration
+public class BricodepotInformesConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotInformesConfiguration.class);
+
+    private static final String INFORMES_CLASSPATH_DIRECTORY = "informes";
+
+    @PostConstruct
+    public void configureReportsBasePath() {
+        if (StringUtils.isNotBlank(AppInfo.getInformesInfo().getRutaBase())) {
+            LOGGER.debug("configureReportsBasePath() - Report base path already configured: {}", AppInfo.getInformesInfo().getRutaBase());
+            return;
+        }
+
+        URL resource = Thread.currentThread().getContextClassLoader().getResource(INFORMES_CLASSPATH_DIRECTORY);
+        if (resource == null) {
+            LOGGER.warn("configureReportsBasePath() - Unable to locate reports directory '{}' on the classpath", INFORMES_CLASSPATH_DIRECTORY);
+            return;
+        }
+
+        try {
+            File informesDirectory = new File(resource.toURI());
+            if (!informesDirectory.exists()) {
+                LOGGER.warn("configureReportsBasePath() - Reports directory '{}' does not exist", informesDirectory);
+                return;
+            }
+
+            String absolutePath = informesDirectory.getAbsolutePath();
+            if (!absolutePath.endsWith(File.separator)) {
+                absolutePath = absolutePath + File.separator;
+            }
+
+            AppInfo.getInformesInfo().setRutaBase(absolutePath, AppInfo.getRutaTrabajo());
+            LOGGER.info("configureReportsBasePath() - Configured reports base path to '{}'", absolutePath);
+        } catch (URISyntaxException exception) {
+            LOGGER.warn("configureReportsBasePath() - Unable to configure reports base path", exception);
+        }
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/domain/salesdocument/BricodepotPrintedDocument.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/domain/salesdocument/BricodepotPrintedDocument.java
@@ -1,0 +1,69 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.domain.salesdocument;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class BricodepotPrintedDocument {
+
+    private final String documentUid;
+    private final String fileName;
+    private final String mimeType;
+    private final byte[] content;
+
+    public BricodepotPrintedDocument(String documentUid, String fileName, String mimeType, byte[] content) {
+        this.documentUid = documentUid;
+        this.fileName = fileName;
+        this.mimeType = mimeType;
+        this.content = content != null ? Arrays.copyOf(content, content.length) : new byte[0];
+    }
+
+    public String getDocumentUid() {
+        return documentUid;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public byte[] getContent() {
+        return Arrays.copyOf(content, content.length);
+    }
+
+    public int getContentLength() {
+        return content.length;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(documentUid, fileName, mimeType, Arrays.hashCode(content));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        BricodepotPrintedDocument other = (BricodepotPrintedDocument) obj;
+        return Objects.equals(this.documentUid, other.documentUid)
+                && Objects.equals(this.fileName, other.fileName)
+                && Objects.equals(this.mimeType, other.mimeType)
+                && Arrays.equals(this.content, other.content);
+    }
+
+    @Override
+    public String toString() {
+        return "BricodepotPrintedDocument{" +
+                "documentUid='" + documentUid + '\'' +
+                ", fileName='" + fileName + '\'' +
+                ", mimeType='" + mimeType + '\'' +
+                ", contentLength=" + content.length +
+                '}';
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/model/salesdocument/BricodepotPrintDocumentResponse.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/model/salesdocument/BricodepotPrintDocumentResponse.java
@@ -1,0 +1,38 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.model.salesdocument;
+
+public class BricodepotPrintDocumentResponse {
+
+    private final String documentUid;
+    private final String fileName;
+    private final String mimeType;
+    private final String base64Content;
+    private final int contentLength;
+
+    public BricodepotPrintDocumentResponse(String documentUid, String fileName, String mimeType, String base64Content, int contentLength) {
+        this.documentUid = documentUid;
+        this.fileName = fileName;
+        this.mimeType = mimeType;
+        this.base64Content = base64Content;
+        this.contentLength = contentLength;
+    }
+
+    public String getDocumentUid() {
+        return documentUid;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public String getBase64Content() {
+        return base64Content;
+    }
+
+    public int getContentLength() {
+        return contentLength;
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintService.java
@@ -1,0 +1,11 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument;
+
+import com.comerzzia.api.core.service.exception.ApiException;
+import com.comerzzia.core.servicios.sesion.IDatosSesion;
+import com.comerzzia.bricodepot.api.omnichannel.api.domain.salesdocument.BricodepotPrintedDocument;
+import com.comerzzia.omnichannel.domain.dto.saledoc.PrintDocumentDTO;
+
+public interface BricodepotSaleDocumentPrintService {
+
+    BricodepotPrintedDocument printDocument(IDatosSesion datosSesion, String documentUid, PrintDocumentDTO printRequest) throws ApiException;
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
@@ -1,0 +1,50 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument;
+
+import java.io.ByteArrayOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.comerzzia.api.core.service.exception.ApiException;
+import com.comerzzia.bricodepot.api.omnichannel.api.domain.salesdocument.BricodepotPrintedDocument;
+import com.comerzzia.core.servicios.sesion.IDatosSesion;
+import com.comerzzia.omnichannel.domain.dto.saledoc.PrintDocumentDTO;
+import com.comerzzia.omnichannel.service.salesdocument.SaleDocumentService;
+
+@Service
+public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDocumentPrintService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotSaleDocumentPrintServiceImpl.class);
+
+    private final SaleDocumentService saleDocumentService;
+
+    @Autowired
+    public BricodepotSaleDocumentPrintServiceImpl(SaleDocumentService saleDocumentService) {
+        this.saleDocumentService = saleDocumentService;
+    }
+
+    @Override
+    public BricodepotPrintedDocument printDocument(IDatosSesion datosSesion, String documentUid, PrintDocumentDTO printRequest) throws ApiException {
+        LOGGER.debug("printDocument() - Generating sales document '{}' with mime type '{}'", documentUid, printRequest.getMimeType());
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            saleDocumentService.printDocument(outputStream, datosSesion, documentUid, printRequest);
+
+            String outputDocumentName = printRequest.getOutputDocumentName();
+            if (!StringUtils.hasText(outputDocumentName)) {
+                outputDocumentName = documentUid;
+            }
+
+            return new BricodepotPrintedDocument(documentUid, outputDocumentName, printRequest.getMimeType(), outputStream.toByteArray());
+        } catch (Exception exception) {
+            LOGGER.error("printDocument() - Error generating sales document '{}'", documentUid, exception);
+            if (exception instanceof ApiException) {
+                throw (ApiException) exception;
+            }
+            throw new ApiException(exception.getMessage(), exception);
+        }
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/rest/salesdoc/BricodepotSalesDocumentResource.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/rest/salesdoc/BricodepotSalesDocumentResource.java
@@ -1,0 +1,111 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.rest.salesdoc;
+
+import java.util.Base64;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+import com.comerzzia.api.core.service.exception.ApiException;
+import com.comerzzia.api.core.service.util.ComerzziaDatosSesion;
+import com.comerzzia.api.omnichannel.web.model.document.PrintDocumentRequest;
+import com.comerzzia.api.omnichannel.web.rest.salesdoc.SalesDocumentResource;
+import com.comerzzia.bricodepot.api.omnichannel.api.domain.salesdocument.BricodepotPrintedDocument;
+import com.comerzzia.bricodepot.api.omnichannel.api.model.salesdocument.BricodepotPrintDocumentResponse;
+import com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument.BricodepotSaleDocumentPrintService;
+import com.comerzzia.omnichannel.domain.dto.saledoc.PrintDocumentDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Path("/salesdocument")
+@Tag(name = "Sales documents", description = "Sales documents services")
+@Controller("salesDocumentResource")
+@Produces(MediaType.APPLICATION_JSON)
+public class BricodepotSalesDocumentResource extends SalesDocumentResource {
+
+    private static final String APPLICATION_PDF = "application/pdf";
+
+    private final BricodepotSaleDocumentPrintService saleDocumentPrintService;
+
+    @Autowired
+    public BricodepotSalesDocumentResource(BricodepotSaleDocumentPrintService saleDocumentPrintService) {
+        this.saleDocumentPrintService = saleDocumentPrintService;
+    }
+
+    @Override
+    @GET
+    @Path("/{documentUid}/print")
+    @Operation(summary = "Print sales document by uid",
+               description = "Print sales document by uid returning a base64 encoded payload",
+               responses = {
+                       @ApiResponse(description = "The print output", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = BricodepotPrintDocumentResponse.class))),
+                       @ApiResponse(responseCode = "400", description = "Invalid input values"),
+                       @ApiResponse(responseCode = "404", description = "Record not found")
+               })
+    public Response printSaleDocumentByUid(@PathParam("documentUid") String documentUid,
+                                           @Context HttpServletRequest request,
+                                           @Context HttpServletResponse response,
+                                           @Valid @BeanParam PrintDocumentRequest printDocumentRequest) throws ApiException {
+
+        PrintDocumentRequest effectiveRequest = printDocumentRequest != null ? printDocumentRequest : new PrintDocumentRequest();
+
+        if (StringUtils.isBlank(effectiveRequest.getMimeType())) {
+            effectiveRequest.setMimeType(APPLICATION_PDF);
+        }
+
+        if (StringUtils.isBlank(effectiveRequest.getOutputDocumentName())) {
+            effectiveRequest.setOutputDocumentName(documentUid);
+        }
+
+        if (effectiveRequest.getInline() == null) {
+            effectiveRequest.setInline(Boolean.FALSE);
+        }
+
+        PrintDocumentDTO printDocumentDTO = super.modelMapper.map(effectiveRequest, PrintDocumentDTO.class);
+
+        Map<String, String> requestCustomParams = effectiveRequest.getCustomParams();
+        if (requestCustomParams != null && !requestCustomParams.isEmpty()) {
+            printDocumentDTO.getCustomParams().putAll(requestCustomParams);
+        }
+
+        ComerzziaDatosSesion datosSesion = super.datosSesionRequest;
+        BricodepotPrintedDocument printedDocument = saleDocumentPrintService.printDocument(datosSesion.getDatosSesionBean(), documentUid, printDocumentDTO);
+
+        String base64Content = Base64.getEncoder().encodeToString(printedDocument.getContent());
+
+        String responseFileName = printedDocument.getFileName();
+        if (StringUtils.isBlank(responseFileName)) {
+            responseFileName = documentUid;
+        }
+
+        if (StringUtils.equals(effectiveRequest.getMimeType(), APPLICATION_PDF) && !StringUtils.endsWithIgnoreCase(responseFileName, ".pdf")) {
+            responseFileName = responseFileName + ".pdf";
+        }
+
+        BricodepotPrintDocumentResponse responseBody = new BricodepotPrintDocumentResponse(
+                printedDocument.getDocumentUid(),
+                responseFileName,
+                printedDocument.getMimeType(),
+                base64Content,
+                printedDocument.getContentLength());
+
+        return Response.ok(responseBody, MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/src/main/resources/comerzzia-api-context.xml
+++ b/src/main/resources/comerzzia-api-context.xml
@@ -16,7 +16,9 @@
     <bean id="AppInfo" class="com.comerzzia.core.util.config.AppInfo" lazy-init="false"/>
     <context:component-scan base-package="com.comerzzia.core.servicios" />
 
-    <context:component-scan base-package="com.comerzzia.api" />
+    <context:component-scan base-package="com.comerzzia.api">
+        <context:exclude-filter type="assignable" expression="com.comerzzia.api.omnichannel.web.rest.salesdoc.SalesDocumentResource" />
+    </context:component-scan>
     <context:component-scan base-package="com.comerzzia.bricodepot.api" />
     <context:component-scan base-package="com.comerzzia.bricodepot.backoffice.services" />
     <context:component-scan base-package="com.comerzzia.core.servicios" />


### PR DESCRIPTION
## Summary
- configure the Jasper reports base path from the bundled `informes` resources so the API can locate report templates
- add Bricodepot-specific domain, service, and web models to generate sales document PDFs and expose their base64 encoding
- override the `/salesdocument/{documentUid}/print` endpoint to return a JSON response containing the generated PDF metadata and base64 payload
- ensure the informes configuration and PDF defaults compile by using the proper `AppInfo` helper and an explicit MIME type constant
- add the required `BricodepotApplication` Spring Boot entry point for the omnichannel API module
- rename the custom omnichannel classes to use the Bricodepot prefix as requested
- exclude the standard `SalesDocumentResource` from component scanning so the Bricodepot override registers without bean conflicts
- align the `comerzzia-omnichannel-services` dependency with version `4.8-SNAPSHOT` per the updated BOM

## Testing
- `mvn -q -DskipTests package` *(fails: blocked from downloading com.lowagie:itext:2.1.7.js6 from jaspersoft mirrors)*

------
https://chatgpt.com/codex/tasks/task_e_68f9efc94778832b833a60ec88a8a55d