### PR TITLE
Add Jersey customizations for Bricodepot sales document printing

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/config/JerseyCustomizationConfiguration.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/config/JerseyCustomizationConfiguration.java
@@ -1,0 +1,31 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.config;
+
+import org.springframework.boot.autoconfigure.jersey.ResourceConfigCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.comerzzia.bricodepot.api.omnichannel.api.web.rest.salesdoc.BricodepotSalesDocumentResource;
+import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.DocumentoVentaImpresionFilter;
+import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.DocumentoVentaImpresionServicio;
+
+@Configuration
+public class JerseyCustomizationConfiguration {
+
+    @Bean
+    public DocumentoVentaImpresionFilter documentoVentaImpresionFilter(
+            DocumentoVentaImpresionServicio servicioImpresion) {
+        return new DocumentoVentaImpresionFilter(servicioImpresion);
+    }
+
+    @Bean
+    public ResourceConfigCustomizer documentoVentaImpresionFilterCustomizer(
+            DocumentoVentaImpresionFilter documentoVentaImpresionFilter) {
+        return resourceConfig -> resourceConfig.register(documentoVentaImpresionFilter);
+    }
+
+    @Bean
+    public ResourceConfigCustomizer bricodepotSalesDocumentResourceCustomizer(
+            BricodepotSalesDocumentResource bricodepotSalesDocumentResource) {
+        return resourceConfig -> resourceConfig.register(bricodepotSalesDocumentResource);
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionFilter.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionFilter.java
@@ -1,0 +1,86 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+@Provider
+public class DocumentoVentaImpresionFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String DOCUMENT_UID_PARAM = "documentUid";
+    private static final String START_TIME_ATTRIBUTE = DocumentoVentaImpresionFilter.class.getName() + ".start";
+
+    private final DocumentoVentaImpresionServicio servicioImpresion;
+
+    public DocumentoVentaImpresionFilter(DocumentoVentaImpresionServicio servicioImpresion) {
+        this.servicioImpresion = servicioImpresion;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (!isSalesDocumentPrintRequest(requestContext)) {
+            return;
+        }
+
+        requestContext.setProperty(START_TIME_ATTRIBUTE, Instant.now());
+        servicioImpresion.registrarInicioImpresion(resolveDocumentUid(requestContext));
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        if (!isSalesDocumentPrintRequest(requestContext)) {
+            return;
+        }
+
+        Object value = requestContext.getProperty(START_TIME_ATTRIBUTE);
+        Instant startInstant = value instanceof Instant ? (Instant) value : null;
+        servicioImpresion.registrarFinImpresion(resolveDocumentUid(requestContext), responseContext.getStatus(), startInstant);
+    }
+
+    private boolean isSalesDocumentPrintRequest(ContainerRequestContext requestContext) {
+        if (requestContext == null || requestContext.getUriInfo() == null) {
+            return false;
+        }
+        String path = requestContext.getUriInfo().getPath();
+        return path != null && path.startsWith("salesdocument/") && path.endsWith("/print");
+    }
+
+    private String resolveDocumentUid(ContainerRequestContext requestContext) {
+        if (requestContext == null || requestContext.getUriInfo() == null) {
+            return null;
+        }
+
+        MultivaluedMap<String, String> pathParameters = requestContext.getUriInfo().getPathParameters();
+        if (pathParameters == null) {
+            return null;
+        }
+
+        List<String> values = pathParameters.get(DOCUMENT_UID_PARAM);
+        if (!CollectionUtils.isEmpty(values)) {
+            return values.get(0);
+        }
+
+        // Fallback in case the parameter name is not exposed for some reason
+        for (Map.Entry<String, List<String>> entry : pathParameters.entrySet()) {
+            if (!CollectionUtils.isEmpty(entry.getValue())) {
+                String candidate = entry.getValue().get(0);
+                if (StringUtils.hasText(candidate)) {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionServicio.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionServicio.java
@@ -1,0 +1,36 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DocumentoVentaImpresionServicio {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentoVentaImpresionServicio.class);
+
+    public void registrarInicioImpresion(String documentUid) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("registrarInicioImpresion() - Starting print generation for document '{}'", documentUid);
+        }
+    }
+
+    public void registrarFinImpresion(String documentUid, int statusCode, Instant startInstant) {
+        if (!LOGGER.isDebugEnabled()) {
+            return;
+        }
+
+        long elapsedMillis = -1L;
+        if (startInstant != null) {
+            elapsedMillis = Duration.between(startInstant, Instant.now()).toMillis();
+        }
+
+        String durationPart = elapsedMillis >= 0 ? " in " + elapsedMillis + " ms" : StringUtils.EMPTY;
+        LOGGER.debug("registrarFinImpresion() - Completed print generation for document '{}' with status {}{}", documentUid,
+                statusCode, durationPart);
+    }
+}


### PR DESCRIPTION
## Summary
- register the Bricodepot sales document resource with Jersey so the endpoint is exposed
- introduce a request/response filter and service that log print operations for sales documents

## Testing
- mvn -q -DskipTests package *(fails: blocked mirror for com.lowagie:itext)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fee283c4832bb3537ac51f5a4e3d