### PR TITLE
Fix sales document template lookup

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -1,0 +1,68 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint;
+
+import java.io.File;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.core.util.config.AppInfo;
+import com.comerzzia.omnichannel.service.documentprint.DocumentPrintServiceImpl;
+
+@Service
+@Primary
+public class BricodepotDocumentPrintService extends DocumentPrintServiceImpl {
+
+    @Override
+    protected File getTemplateLocaleFile(String template, String localeId) {
+        File templateFile = super.getTemplateLocaleFile(template, localeId);
+        if (templateFile.exists()) {
+            return templateFile;
+        }
+
+        File alternative = resolveFromReportsDirectory(template, localeId);
+        if (alternative.exists()) {
+            return alternative;
+        }
+
+        return templateFile;
+    }
+
+    private File resolveFromReportsDirectory(String template, String localeId) {
+        String basePath = AppInfo.getInformesInfo().getRutaBase();
+        if (StringUtils.isBlank(basePath)) {
+            basePath = "";
+        }
+
+        if (!basePath.endsWith(File.separator)) {
+            basePath = basePath + File.separator;
+        }
+
+        File candidate = buildTemplateCandidate(basePath + template, localeId);
+        if (!candidate.exists() && template.contains("/")) {
+            String normalizedTemplate = template.replace('/', File.separatorChar);
+            candidate = buildTemplateCandidate(basePath + normalizedTemplate, localeId);
+        }
+
+        return candidate;
+    }
+
+    private File buildTemplateCandidate(String partialFileName, String localeId) {
+        String locale = localeId != null ? localeId.toLowerCase() : null;
+        String extension = getTemplateExtension();
+        File result = null;
+
+        if (StringUtils.isNotBlank(locale)) {
+            result = new File(partialFileName + "_" + locale + extension);
+            if (!result.exists() && locale.length() >= 2) {
+                result = new File(partialFileName + "_" + StringUtils.left(locale, 2) + extension);
+            }
+        }
+
+        if (result == null || !result.exists()) {
+            result = new File(partialFileName + extension);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
@@ -1,0 +1,61 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument.metadata;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.core.servicios.sesion.IDatosSesion;
+import com.comerzzia.omnichannel.domain.entity.document.DocumentEntity;
+import com.comerzzia.omnichannel.service.salesdocument.metadata.DocumentMetadata;
+import com.comerzzia.omnichannel.service.salesdocument.metadata.DocumentMetadataParser;
+
+@Component
+@Primary
+public class BricodepotDocumentMetadataParser extends DocumentMetadataParser {
+
+    private static final Map<String, String> TEMPLATE_ALIASES;
+
+    static {
+        Map<String, String> aliases = new HashMap<>();
+        aliases.put("FT", "ventas/facturas/facturaA4");
+        aliases.put("FS", "ventas/facturas/facturaA4");
+        aliases.put("NC", "ventas/facturas/facturaA4");
+        aliases.put("VC", "ventas/facturas/facturaA4");
+        TEMPLATE_ALIASES = Collections.unmodifiableMap(aliases);
+    }
+
+    @Override
+    public DocumentMetadata getMetadata(IDatosSesion datosSesion, DocumentEntity document) {
+        DocumentMetadata metadata = super.getMetadata(datosSesion, document);
+        applyTemplateOverride(metadata);
+        return metadata;
+    }
+
+    @Override
+    public DocumentMetadata getMetadata(IDatosSesion datosSesion, byte[] documentContent) {
+        DocumentMetadata metadata = super.getMetadata(datosSesion, documentContent);
+        applyTemplateOverride(metadata);
+        return metadata;
+    }
+
+    private void applyTemplateOverride(DocumentMetadata metadata) {
+        if (metadata == null || StringUtils.isNotBlank(metadata.getPrintTemplate())) {
+            return;
+        }
+
+        String docTypeCode = metadata.getDocTypeCode();
+        String template = TEMPLATE_ALIASES.get(docTypeCode);
+
+        if (StringUtils.isBlank(template) && StringUtils.isNotBlank(docTypeCode) && docTypeCode.startsWith("FT")) {
+            template = "ventas/facturas/facturaA4";
+        }
+
+        if (StringUtils.isNotBlank(template)) {
+            metadata.setPrintTemplate(template);
+        }
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/config/JerseyCustomizationConfiguration.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/config/JerseyCustomizationConfiguration.java
@@ -1,0 +1,31 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.config;
+
+import org.springframework.boot.autoconfigure.jersey.ResourceConfigCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.comerzzia.bricodepot.api.omnichannel.api.web.rest.salesdoc.BricodepotSalesDocumentResource;
+import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.DocumentoVentaImpresionFilter;
+import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.DocumentoVentaImpresionServicio;
+
+@Configuration
+public class JerseyCustomizationConfiguration {
+
+    @Bean
+    public DocumentoVentaImpresionFilter documentoVentaImpresionFilter(
+            DocumentoVentaImpresionServicio servicioImpresion) {
+        return new DocumentoVentaImpresionFilter(servicioImpresion);
+    }
+
+    @Bean
+    public ResourceConfigCustomizer documentoVentaImpresionFilterCustomizer(
+            DocumentoVentaImpresionFilter documentoVentaImpresionFilter) {
+        return resourceConfig -> resourceConfig.register(documentoVentaImpresionFilter);
+    }
+
+    @Bean
+    public ResourceConfigCustomizer bricodepotSalesDocumentResourceCustomizer(
+            BricodepotSalesDocumentResource bricodepotSalesDocumentResource) {
+        return resourceConfig -> resourceConfig.register(bricodepotSalesDocumentResource);
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionFilter.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionFilter.java
@@ -1,0 +1,86 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+@Provider
+public class DocumentoVentaImpresionFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String DOCUMENT_UID_PARAM = "documentUid";
+    private static final String START_TIME_ATTRIBUTE = DocumentoVentaImpresionFilter.class.getName() + ".start";
+
+    private final DocumentoVentaImpresionServicio servicioImpresion;
+
+    public DocumentoVentaImpresionFilter(DocumentoVentaImpresionServicio servicioImpresion) {
+        this.servicioImpresion = servicioImpresion;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (!isSalesDocumentPrintRequest(requestContext)) {
+            return;
+        }
+
+        requestContext.setProperty(START_TIME_ATTRIBUTE, Instant.now());
+        servicioImpresion.registrarInicioImpresion(resolveDocumentUid(requestContext));
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        if (!isSalesDocumentPrintRequest(requestContext)) {
+            return;
+        }
+
+        Object value = requestContext.getProperty(START_TIME_ATTRIBUTE);
+        Instant startInstant = value instanceof Instant ? (Instant) value : null;
+        servicioImpresion.registrarFinImpresion(resolveDocumentUid(requestContext), responseContext.getStatus(), startInstant);
+    }
+
+    private boolean isSalesDocumentPrintRequest(ContainerRequestContext requestContext) {
+        if (requestContext == null || requestContext.getUriInfo() == null) {
+            return false;
+        }
+        String path = requestContext.getUriInfo().getPath();
+        return path != null && path.startsWith("salesdocument/") && path.endsWith("/print");
+    }
+
+    private String resolveDocumentUid(ContainerRequestContext requestContext) {
+        if (requestContext == null || requestContext.getUriInfo() == null) {
+            return null;
+        }
+
+        MultivaluedMap<String, String> pathParameters = requestContext.getUriInfo().getPathParameters();
+        if (pathParameters == null) {
+            return null;
+        }
+
+        List<String> values = pathParameters.get(DOCUMENT_UID_PARAM);
+        if (!CollectionUtils.isEmpty(values)) {
+            return values.get(0);
+        }
+
+        // Fallback in case the parameter name is not exposed for some reason
+        for (Map.Entry<String, List<String>> entry : pathParameters.entrySet()) {
+            if (!CollectionUtils.isEmpty(entry.getValue())) {
+                String candidate = entry.getValue().get(0);
+                if (StringUtils.hasText(candidate)) {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionServicio.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionServicio.java
@@ -1,0 +1,36 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DocumentoVentaImpresionServicio {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentoVentaImpresionServicio.class);
+
+    public void registrarInicioImpresion(String documentUid) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("registrarInicioImpresion() - Starting print generation for document '{}'", documentUid);
+        }
+    }
+
+    public void registrarFinImpresion(String documentUid, int statusCode, Instant startInstant) {
+        if (!LOGGER.isDebugEnabled()) {
+            return;
+        }
+
+        long elapsedMillis = -1L;
+        if (startInstant != null) {
+            elapsedMillis = Duration.between(startInstant, Instant.now()).toMillis();
+        }
+
+        String durationPart = elapsedMillis >= 0 ? " in " + elapsedMillis + " ms" : StringUtils.EMPTY;
+        LOGGER.debug("registrarFinImpresion() - Completed print generation for document '{}' with status {}{}", documentUid,
+                statusCode, durationPart);
+    }
+}


### PR DESCRIPTION
## Summary
- override the sales document metadata parser so Bricodepot invoices default to the facturaA4 Jasper template when no explicit template is provided
- customize the Jasper document print service to resolve templates from the reports resources directory instead of the standard doctemplates folder

## Testing
- mvn -q -DskipTests package *(fails: blocked mirror for com.lowagie:itext)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fee283c4832bb3537ac51f5a4e3d