### PR TITLE
Ensure sales document printing uses custom templates

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
@@ -2,6 +2,7 @@ package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument.meta
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -17,14 +18,18 @@ import com.comerzzia.omnichannel.service.salesdocument.metadata.DocumentMetadata
 @Primary
 public class BricodepotDocumentMetadataParser extends DocumentMetadataParser {
 
+    private static final String DEFAULT_FACTURA_TEMPLATE = "ventas/facturas/facturaA4";
+
     private static final Map<String, String> TEMPLATE_ALIASES;
 
     static {
         Map<String, String> aliases = new HashMap<>();
-        aliases.put("FT", "ventas/facturas/facturaA4");
-        aliases.put("FS", "ventas/facturas/facturaA4");
-        aliases.put("NC", "ventas/facturas/facturaA4");
-        aliases.put("VC", "ventas/facturas/facturaA4");
+        registerAlias(aliases, "FT", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "FS", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "NC", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "VC", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "facturaA4", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "factura", DEFAULT_FACTURA_TEMPLATE);
         TEMPLATE_ALIASES = Collections.unmodifiableMap(aliases);
     }
 
@@ -43,19 +48,60 @@ public class BricodepotDocumentMetadataParser extends DocumentMetadataParser {
     }
 
     private void applyTemplateOverride(DocumentMetadata metadata) {
-        if (metadata == null || StringUtils.isNotBlank(metadata.getPrintTemplate())) {
+        if (metadata == null) {
             return;
         }
 
-        String docTypeCode = metadata.getDocTypeCode();
-        String template = TEMPLATE_ALIASES.get(docTypeCode);
+        String currentTemplate = metadata.getPrintTemplate();
+        if (StringUtils.isNotBlank(currentTemplate) && !isGenericTemplateName(currentTemplate)) {
+            return;
+        }
 
-        if (StringUtils.isBlank(template) && StringUtils.isNotBlank(docTypeCode) && docTypeCode.startsWith("FT")) {
-            template = "ventas/facturas/facturaA4";
+        String template = resolveAlias(currentTemplate);
+        if (StringUtils.isBlank(template)) {
+            template = resolveAlias(metadata.getDocTypeCode());
+        }
+
+        if (StringUtils.isBlank(template)) {
+            String normalizedDocType = normalizeKey(metadata.getDocTypeCode());
+            if (StringUtils.isNotBlank(normalizedDocType) && normalizedDocType.startsWith("FT")) {
+                template = DEFAULT_FACTURA_TEMPLATE;
+            }
         }
 
         if (StringUtils.isNotBlank(template)) {
             metadata.setPrintTemplate(template);
         }
+    }
+
+    private static void registerAlias(Map<String, String> target, String key, String value) {
+        String normalized = normalizeKey(key);
+        if (normalized != null) {
+            target.put(normalized, value);
+        }
+    }
+
+    private static String normalizeKey(String key) {
+        if (StringUtils.isBlank(key)) {
+            return null;
+        }
+
+        String trimmed = key.trim();
+        trimmed = StringUtils.substringBefore(trimmed, "/");
+        trimmed = StringUtils.substringBefore(trimmed, " ");
+
+        return trimmed.toUpperCase(Locale.ROOT);
+    }
+
+    private String resolveAlias(String key) {
+        String normalized = normalizeKey(key);
+        if (normalized == null) {
+            return null;
+        }
+        return TEMPLATE_ALIASES.get(normalized);
+    }
+
+    private boolean isGenericTemplateName(String template) {
+        return StringUtils.isNotBlank(template) && !StringUtils.containsAny(template, '/', '\\');
     }
 }


### PR DESCRIPTION
## Summary
- normalize sales document template aliases so invoice requests map to the custom BricoDepot resources
- fall back to the project-specific factura template when a generic print template is provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa3680457c832b857dd1f6e9e72161