### PR TITLE
Compile BricoDepot Jasper templates from project resources

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -1,31 +1,135 @@
 package com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint;
 
 import java.io.File;
+import java.io.FileFilter;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.comerzzia.core.util.config.AppInfo;
 import com.comerzzia.omnichannel.service.documentprint.jasper.JasperPrintServiceImpl;
 
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JasperCompileManager;
+
 @Service
 @Primary
 public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotDocumentPrintService.class);
+    private static final Set<String> COMPILED_TEMPLATES = ConcurrentHashMap.newKeySet();
+
     @Override
     protected File getTemplateLocaleFile(String template, String localeId) {
         File templateFile = super.getTemplateLocaleFile(template, localeId);
+        compileTemplateIfNecessary(templateFile);
         if (templateFile.exists()) {
             return templateFile;
         }
 
         File alternative = resolveFromReportsDirectory(template, localeId);
+        compileTemplateIfNecessary(alternative);
         if (alternative.exists()) {
             return alternative;
         }
 
         return templateFile;
+    }
+
+    private void compileTemplateIfNecessary(File jasperFile) {
+        if (jasperFile == null) {
+            return;
+        }
+
+        String absolutePath = jasperFile.getAbsolutePath();
+        if (COMPILED_TEMPLATES.contains(absolutePath)) {
+            return;
+        }
+
+        File jrxmlFile = toJrxmlFile(jasperFile);
+        if (jrxmlFile == null || !jrxmlFile.exists()) {
+            COMPILED_TEMPLATES.add(absolutePath);
+            return;
+        }
+
+        ensureParentDirectory(jasperFile);
+
+        try {
+            JasperCompileManager.compileReportToFile(jrxmlFile.getAbsolutePath(), jasperFile.getAbsolutePath());
+            COMPILED_TEMPLATES.add(absolutePath);
+            compileSiblingTemplates(jrxmlFile.getParentFile(), jrxmlFile);
+        } catch (JRException exception) {
+            LOGGER.warn("Failed to compile Jasper template '{}' from '{}'", absolutePath, jrxmlFile.getAbsolutePath(), exception);
+        }
+    }
+
+    private void compileSiblingTemplates(File directory, File primaryJrxml) {
+        if (directory == null || !directory.isDirectory()) {
+            return;
+        }
+
+        File[] jrxmlFiles = directory.listFiles(new JrxmlFilter());
+        if (jrxmlFiles == null) {
+            return;
+        }
+
+        for (File jrxmlFile : jrxmlFiles) {
+            if (primaryJrxml != null && primaryJrxml.equals(jrxmlFile)) {
+                continue;
+            }
+            File jasperFile = toJasperFile(jrxmlFile);
+            if (jasperFile == null) {
+                continue;
+            }
+            ensureParentDirectory(jasperFile);
+
+            try {
+                if (!jasperFile.exists() || jrxmlFile.lastModified() >= jasperFile.lastModified()) {
+                    JasperCompileManager.compileReportToFile(jrxmlFile.getAbsolutePath(), jasperFile.getAbsolutePath());
+                }
+                COMPILED_TEMPLATES.add(jasperFile.getAbsolutePath());
+            } catch (JRException exception) {
+                LOGGER.warn("Failed to compile Jasper subreport '{}'", jrxmlFile.getAbsolutePath(), exception);
+            }
+        }
+    }
+
+    private void ensureParentDirectory(File jasperFile) {
+        File parent = jasperFile.getParentFile();
+        if (parent != null && !parent.exists()) {
+            parent.mkdirs();
+        }
+    }
+
+    private File toJrxmlFile(File jasperFile) {
+        String absolutePath = jasperFile != null ? jasperFile.getAbsolutePath() : null;
+        if (StringUtils.isBlank(absolutePath)) {
+            return null;
+        }
+
+        return new File(StringUtils.substringBeforeLast(absolutePath, ".") + ".jrxml");
+    }
+
+    private File toJasperFile(File jrxmlFile) {
+        String absolutePath = jrxmlFile != null ? jrxmlFile.getAbsolutePath() : null;
+        if (StringUtils.isBlank(absolutePath)) {
+            return null;
+        }
+
+        String jasperPath;
+        if (StringUtils.endsWithIgnoreCase(absolutePath, ".jrxml")) {
+            jasperPath = StringUtils.substringBeforeLast(absolutePath, ".") + getTemplateExtension();
+        } else {
+            jasperPath = absolutePath + getTemplateExtension();
+        }
+
+        return new File(jasperPath);
     }
 
     private File resolveFromReportsDirectory(String template, String localeId) {
@@ -48,7 +152,7 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
     }
 
     private File buildTemplateCandidate(String partialFileName, String localeId) {
-        String locale = localeId != null ? localeId.toLowerCase() : null;
+        String locale = localeId != null ? localeId.toLowerCase(Locale.ROOT) : null;
         String extension = getTemplateExtension();
         File result = null;
 
@@ -64,5 +168,12 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
         }
 
         return result;
+    }
+
+    private static final class JrxmlFilter implements FileFilter {
+        @Override
+        public boolean accept(File pathname) {
+            return pathname.isFile() && StringUtils.endsWithIgnoreCase(pathname.getName(), ".jrxml");
+        }
     }
 }

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
@@ -2,6 +2,7 @@ package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument.meta
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -17,14 +18,18 @@ import com.comerzzia.omnichannel.service.salesdocument.metadata.DocumentMetadata
 @Primary
 public class BricodepotDocumentMetadataParser extends DocumentMetadataParser {
 
+    private static final String DEFAULT_FACTURA_TEMPLATE = "ventas/facturas/facturaA4";
+
     private static final Map<String, String> TEMPLATE_ALIASES;
 
     static {
         Map<String, String> aliases = new HashMap<>();
-        aliases.put("FT", "ventas/facturas/facturaA4");
-        aliases.put("FS", "ventas/facturas/facturaA4");
-        aliases.put("NC", "ventas/facturas/facturaA4");
-        aliases.put("VC", "ventas/facturas/facturaA4");
+        registerAlias(aliases, "FT", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "FS", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "NC", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "VC", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "facturaA4", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "factura", DEFAULT_FACTURA_TEMPLATE);
         TEMPLATE_ALIASES = Collections.unmodifiableMap(aliases);
     }
 
@@ -43,19 +48,60 @@ public class BricodepotDocumentMetadataParser extends DocumentMetadataParser {
     }
 
     private void applyTemplateOverride(DocumentMetadata metadata) {
-        if (metadata == null || StringUtils.isNotBlank(metadata.getPrintTemplate())) {
+        if (metadata == null) {
             return;
         }
 
-        String docTypeCode = metadata.getDocTypeCode();
-        String template = TEMPLATE_ALIASES.get(docTypeCode);
+        String currentTemplate = metadata.getPrintTemplate();
+        if (StringUtils.isNotBlank(currentTemplate) && !isGenericTemplateName(currentTemplate)) {
+            return;
+        }
 
-        if (StringUtils.isBlank(template) && StringUtils.isNotBlank(docTypeCode) && docTypeCode.startsWith("FT")) {
-            template = "ventas/facturas/facturaA4";
+        String template = resolveAlias(currentTemplate);
+        if (StringUtils.isBlank(template)) {
+            template = resolveAlias(metadata.getDocTypeCode());
+        }
+
+        if (StringUtils.isBlank(template)) {
+            String normalizedDocType = normalizeKey(metadata.getDocTypeCode());
+            if (StringUtils.isNotBlank(normalizedDocType) && normalizedDocType.startsWith("FT")) {
+                template = DEFAULT_FACTURA_TEMPLATE;
+            }
         }
 
         if (StringUtils.isNotBlank(template)) {
             metadata.setPrintTemplate(template);
         }
+    }
+
+    private static void registerAlias(Map<String, String> target, String key, String value) {
+        String normalized = normalizeKey(key);
+        if (normalized != null) {
+            target.put(normalized, value);
+        }
+    }
+
+    private static String normalizeKey(String key) {
+        if (StringUtils.isBlank(key)) {
+            return null;
+        }
+
+        String trimmed = key.trim();
+        trimmed = StringUtils.substringBefore(trimmed, "/");
+        trimmed = StringUtils.substringBefore(trimmed, " ");
+
+        return trimmed.toUpperCase(Locale.ROOT);
+    }
+
+    private String resolveAlias(String key) {
+        String normalized = normalizeKey(key);
+        if (normalized == null) {
+            return null;
+        }
+        return TEMPLATE_ALIASES.get(normalized);
+    }
+
+    private boolean isGenericTemplateName(String template) {
+        return StringUtils.isNotBlank(template) && !StringUtils.containsAny(template, '/', '\\');
     }
 }

--- a/src/main/resources/informes/ventas/facturas/SubInfPromociones.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfPromociones.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<field name="idPromocion" class="java.lang.Long">
 		<fieldDescription><![CDATA[idPromocion]]></fieldDescription>
 	</field>

--- a/src/main/resources/informes/ventas/facturas/SubInfPromociones_CA.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfPromociones_CA.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<field name="idPromocion" class="java.lang.Long">
 		<fieldDescription><![CDATA[idPromocion]]></fieldDescription>
 	</field>

--- a/src/main/resources/informes/ventas/facturas/SubInfPromociones_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfPromociones_PT.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<field name="idPromocion" class="java.lang.Long">
 		<fieldDescription><![CDATA[idPromocion]]></fieldDescription>
 	</field>

--- a/src/main/resources/informes/ventas/facturas/facturaA4.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="QR_ESPAÑA" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_CA.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_CA.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="QR_ESPAÑA" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_Original.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_Original.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="QR_ESPAÑA" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_PT.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="QR_PORTUGAL" class="java.io.InputStream"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>


### PR DESCRIPTION
## Summary
- compile Jasper templates from the API's resources whenever the packaged jasper files are missing or outdated
- update the invoice and promotion JRXML templates to use the runtime omnichannel ticket model so custom reports load correctly

## Testing
- not run (maven dependency resolution is blocked by the jaspersoft mirror)

------
https://chatgpt.com/codex/tasks/task_e_68fa3680457c832b857dd1f6e9e72161