### PR TITLE
Fix fiscal data access for ATCUD and payment descriptions

### DIFF
--- a/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta.jrxml
+++ b/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta.jrxml
@@ -6,8 +6,8 @@
 	<queryString>
 		<![CDATA[]]>
 	</queryString>
-	<field name="medioPago" class="java.lang.String">
-		<fieldDescription><![CDATA[medioPago.desMedioPago]]></fieldDescription>
+      <field name="medioPago" class="java.lang.String">
+             <fieldDescription><![CDATA[desMedioPago]]></fieldDescription>
 	</field>
 	<field name="importe" class="java.math.BigDecimal">
 		<fieldDescription><![CDATA[importe]]></fieldDescription>

--- a/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_CA.jrxml
+++ b/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_CA.jrxml
@@ -6,8 +6,8 @@
 	<queryString>
 		<![CDATA[]]>
 	</queryString>
-	<field name="medioPago" class="java.lang.String">
-		<fieldDescription><![CDATA[medioPago.desMedioPago]]></fieldDescription>
+      <field name="medioPago" class="java.lang.String">
+             <fieldDescription><![CDATA[desMedioPago]]></fieldDescription>
 	</field>
 	<field name="importe" class="java.math.BigDecimal">
 		<fieldDescription><![CDATA[importe]]></fieldDescription>

--- a/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_PT.jrxml
+++ b/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_PT.jrxml
@@ -6,8 +6,8 @@
 	<queryString>
 		<![CDATA[]]>
 	</queryString>
-	<field name="medioPago" class="java.lang.String">
-		<fieldDescription><![CDATA[medioPago.desMedioPago]]></fieldDescription>
+      <field name="medioPago" class="java.lang.String">
+             <fieldDescription><![CDATA[desMedioPago]]></fieldDescription>
 	</field>
 	<field name="importe" class="java.math.BigDecimal">
 		<fieldDescription><![CDATA[importe]]></fieldDescription>

--- a/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
+++ b/bo/comerzzia-custom-backoffice-resources/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
@@ -650,15 +650,15 @@ $P{ticket}.getCabecera().getDatosDocOrigen().getCodTicket() :
 				<textFieldExpression><![CDATA["Software Version: "+($P{ticket}.getSoftwareVersion())]]></textFieldExpression>
 			</textField>
 			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement uuid="85581467-17fc-4949-bb28-a16f878f4346" x="181" y="12" width="233" height="14">
-					<printWhenExpression><![CDATA[$P{ticket}.getCabecera().getFiscalData().getProperty("ATCUD") != null &&
-$P{ticket}.getCabecera().getFiscalData().getProperty("ATCUD").getValue() != null]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA["ATCUD: " + $P{ticket}.getCabecera().getFiscalData().getProperty("ATCUD").getValue()]]></textFieldExpression>
-			</textField>
+                                <reportElement uuid="85581467-17fc-4949-bb28-a16f878f4346" x="181" y="12" width="233" height="14">
+                                        <printWhenExpression><![CDATA[$P{ticket}.getCabecera().getFiscalData() != null &&
+$P{ticket}.getCabecera().getFiscalData().getPropertyValue("ATCUD") != null]]></printWhenExpression>
+                                </reportElement>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA["ATCUD: " + $P{ticket}.getCabecera().getFiscalData().getPropertyValue("ATCUD")]]></textFieldExpression>
+                        </textField>
 		</band>
 	</lastPageFooter>
 </jasperReport>

--- a/estandar/comerzzia-basket-calculator-services/src/main/java/com/comerzzia/pos/services/fiscaldata/FiscalData.java
+++ b/estandar/comerzzia-basket-calculator-services/src/main/java/com/comerzzia/pos/services/fiscaldata/FiscalData.java
@@ -1,33 +1,97 @@
 package com.comerzzia.pos.services.fiscaldata;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlValue;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public class FiscalData {
-	
-	@XmlAttribute(name="content_type")
-	protected String contentType;
-	
-	@XmlValue
-	protected String data;
 
-	public String getContentType() {
-		return contentType;
-	}
+    @XmlAttribute(name = "content_type")
+    protected String contentType;
 
-	public void setContentType(String contentType) {
-		this.contentType = contentType;
-	}
+    @XmlValue
+    protected String data;
 
-	public String getData() {
-		return data;
-	}
+    @XmlElement(name = "property")
+    protected List<FiscalDataProperty> properties;
 
-	public void setData(String data) {
-		this.data = data;
-	}
+    public String getContentType() {
+        return contentType;
+    }
 
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public List<FiscalDataProperty> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<FiscalDataProperty> properties) {
+        this.properties = properties;
+    }
+
+    public FiscalDataProperty getProperty(String name) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+
+        String normalized = normalize(name);
+        if (normalized == null) {
+            return null;
+        }
+
+        for (FiscalDataProperty property : properties) {
+            if (property == null) {
+                continue;
+            }
+
+            String propertyName = normalize(property.getName());
+            if (propertyName != null && propertyName.equalsIgnoreCase(normalized)) {
+                return property;
+            }
+        }
+
+        return null;
+    }
+
+    public String getPropertyValue(String name) {
+        FiscalDataProperty property = getProperty(name);
+        return property != null ? property.getValue() : null;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    public void addProperty(FiscalDataProperty property) {
+        if (property == null) {
+            return;
+        }
+
+        if (this.properties == null) {
+            this.properties = new ArrayList<FiscalDataProperty>();
+        }
+
+        this.properties.add(property);
+    }
 }

--- a/estandar/comerzzia-basket-calculator-services/src/main/java/com/comerzzia/pos/services/fiscaldata/FiscalDataProperty.java
+++ b/estandar/comerzzia-basket-calculator-services/src/main/java/com/comerzzia/pos/services/fiscaldata/FiscalDataProperty.java
@@ -1,0 +1,39 @@
+package com.comerzzia.pos.services.fiscaldata;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class FiscalDataProperty {
+
+    @XmlElement(name = "name")
+    protected String name;
+
+    @XmlElement(name = "value")
+    protected String value;
+
+    public FiscalDataProperty() {
+    }
+
+    public FiscalDataProperty(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/estandar/comerzzia-basket-calculator-services/src/main/java/com/comerzzia/pos/services/ticket/cabecera/CabeceraTicket.java
+++ b/estandar/comerzzia-basket-calculator-services/src/main/java/com/comerzzia/pos/services/ticket/cabecera/CabeceraTicket.java
@@ -96,15 +96,18 @@ public class CabeceraTicket extends CabeceraTicketAbstract<SubtotalIvaTicket, IT
 		}
 	}
 		
-	@Override
-	public FiscalData getFiscalData() {
-		return fiscalData;
-	}
+@Override
+public FiscalData getFiscalData() {
+if (fiscalData == null) {
+fiscalData = new FiscalData();
+}
+return fiscalData;
+}
 
-	@Override
-	public void setFiscalData(FiscalData fiscalData) {
-		this.fiscalData = fiscalData;
-	}
+@Override
+public void setFiscalData(FiscalData fiscalData) {
+this.fiscalData = fiscalData;
+}
 	
 	@Override
 	public LinkedHashSet<String> getTarifas()  {

--- a/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta.jrxml
@@ -6,8 +6,8 @@
 	<queryString>
 		<![CDATA[]]>
 	</queryString>
-	<field name="medioPago" class="java.lang.String">
-		<fieldDescription><![CDATA[medioPago.desMedioPago]]></fieldDescription>
+      <field name="medioPago" class="java.lang.String">
+             <fieldDescription><![CDATA[desMedioPago]]></fieldDescription>
 	</field>
 	<field name="importe" class="java.math.BigDecimal">
 		<fieldDescription><![CDATA[importe]]></fieldDescription>

--- a/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_CA.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_CA.jrxml
@@ -6,8 +6,8 @@
 	<queryString>
 		<![CDATA[]]>
 	</queryString>
-	<field name="medioPago" class="java.lang.String">
-		<fieldDescription><![CDATA[medioPago.desMedioPago]]></fieldDescription>
+      <field name="medioPago" class="java.lang.String">
+             <fieldDescription><![CDATA[desMedioPago]]></fieldDescription>
 	</field>
 	<field name="importe" class="java.math.BigDecimal">
 		<fieldDescription><![CDATA[importe]]></fieldDescription>

--- a/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfAlbaranVentas_PagosACuenta_PT.jrxml
@@ -6,8 +6,8 @@
 	<queryString>
 		<![CDATA[]]>
 	</queryString>
-	<field name="medioPago" class="java.lang.String">
-		<fieldDescription><![CDATA[medioPago.desMedioPago]]></fieldDescription>
+      <field name="medioPago" class="java.lang.String">
+             <fieldDescription><![CDATA[desMedioPago]]></fieldDescription>
 	</field>
 	<field name="importe" class="java.math.BigDecimal">
 		<fieldDescription><![CDATA[importe]]></fieldDescription>

--- a/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
@@ -650,15 +650,15 @@ $P{ticket}.getCabecera().getDatosDocOrigen().getCodTicket() :
 				<textFieldExpression><![CDATA["Software Version: "+($P{ticket}.getSoftwareVersion())]]></textFieldExpression>
 			</textField>
 			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement uuid="85581467-17fc-4949-bb28-a16f878f4346" x="181" y="12" width="233" height="14">
-					<printWhenExpression><![CDATA[$P{ticket}.getCabecera().getFiscalData().getProperty("ATCUD") != null &&
-$P{ticket}.getCabecera().getFiscalData().getProperty("ATCUD").getValue() != null]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA["ATCUD: " + $P{ticket}.getCabecera().getFiscalData().getProperty("ATCUD").getValue()]]></textFieldExpression>
-			</textField>
+                                <reportElement uuid="85581467-17fc-4949-bb28-a16f878f4346" x="181" y="12" width="233" height="14">
+                                        <printWhenExpression><![CDATA[$P{ticket}.getCabecera().getFiscalData() != null &&
+$P{ticket}.getCabecera().getFiscalData().getPropertyValue("ATCUD") != null]]></printWhenExpression>
+                                </reportElement>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA["ATCUD: " + $P{ticket}.getCabecera().getFiscalData().getPropertyValue("ATCUD")]]></textFieldExpression>
+                        </textField>
 		</band>
 	</lastPageFooter>
 </jasperReport>


### PR DESCRIPTION
## Summary
- extend fiscal data model to expose properties and values for report usage
- ensure ticket headers always provide a fiscal data instance
- update invoice and payment subreports to use safe fiscal data/property lookups

## Testing
- `mvn -pl estandar/comerzzia-basket-calculator-services -am -DskipTests package` *(fails: Could not find the selected project in the reactor)*

------
https://chatgpt.com/codex/tasks/task_e_68fb6a3a0b48832ba62ad4f533719492