### PR TITLE
Fix ATCUD extraction for sales document printing

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -2,9 +2,13 @@ package com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -58,6 +62,7 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
             return;
         }
 
+        ensurePortugueseTemplateCompatibility(jrxmlFile);
         ensureParentDirectory(jasperFile);
 
         try {
@@ -67,6 +72,68 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
         } catch (JRException exception) {
             LOGGER.warn("Failed to compile Jasper template '{}' from '{}'", absolutePath, jrxmlFile.getAbsolutePath(), exception);
         }
+    }
+
+    private void ensurePortugueseTemplateCompatibility(File jrxmlFile) {
+        if (jrxmlFile == null) {
+            return;
+        }
+
+        String name = jrxmlFile.getName();
+        if (!"facturaA4_PT.jrxml".equalsIgnoreCase(name) && !"facturaDevolucionA4_PT.jrxml".equalsIgnoreCase(name)) {
+            return;
+        }
+
+        try {
+            String content = Files.readString(jrxmlFile.toPath(), StandardCharsets.UTF_8);
+            String updatedContent = patchAtcudExpressions(content);
+
+            if (!updatedContent.equals(content)) {
+                Files.writeString(jrxmlFile.toPath(), updatedContent, StandardCharsets.UTF_8);
+                LOGGER.debug("ensurePortugueseTemplateCompatibility() - Patched fiscal data expressions in '{}'", jrxmlFile.getAbsolutePath());
+            }
+        } catch (IOException exception) {
+            LOGGER.warn("ensurePortugueseTemplateCompatibility() - Unable to adjust template '{}'", jrxmlFile.getAbsolutePath(), exception);
+        }
+    }
+
+    private String patchAtcudExpressions(String content) {
+        if (content == null) {
+            return "";
+        }
+
+        String result = content;
+        if (!result.contains("name=\"fiscalData_ACTUD\"")) {
+            result = injectFiscalParameters(result);
+        } else if (!result.contains("name=\"fiscalData_QR\"")) {
+            result = result.replace("name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>",
+                    "name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>");
+        }
+
+        result = PROPERTY_VALUE_PATTERN.matcher(result).replaceAll("$P{fiscalData_ACTUD}");
+        result = PROPERTY_PATTERN.matcher(result).replaceAll("$P{fiscalData_ACTUD}");
+
+        return result;
+    }
+
+    private String injectFiscalParameters(String content) {
+        String marker = "<parameter name=\"ticket\"";
+        int markerIndex = content.indexOf(marker);
+        if (markerIndex < 0) {
+            return content;
+        }
+
+        int insertIndex = content.indexOf('\n', markerIndex);
+        if (insertIndex < 0) {
+            insertIndex = markerIndex + marker.length();
+        }
+
+        StringBuilder builder = new StringBuilder(content.length() + 160);
+        builder.append(content, 0, insertIndex + 1);
+        builder.append("        <parameter name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n");
+        builder.append("        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>\n");
+        builder.append(content.substring(insertIndex + 1));
+        return builder.toString();
     }
 
     private void compileSiblingTemplates(File directory, File primaryJrxml) {
@@ -176,4 +243,7 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
             return pathname.isFile() && StringUtils.endsWithIgnoreCase(pathname.getName(), ".jrxml");
         }
     }
+
+    private static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\.getProperty\\(\\\"ATCUD\\\"\\)");
+    private static final Pattern PROPERTY_VALUE_PATTERN = Pattern.compile("\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\.getProperty(?:Value)?\\(\\\"ATCUD\\\"\\)(?:\\.getValue\\(\\))?");
 }

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
@@ -1,7 +1,14 @@
 package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import javax.imageio.ImageIO;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -24,17 +32,28 @@ import com.comerzzia.omnichannel.domain.dto.saledoc.PrintDocumentDTO;
 import com.comerzzia.omnichannel.domain.entity.document.DocumentEntity;
 import com.comerzzia.omnichannel.service.document.DocumentService;
 import com.comerzzia.omnichannel.service.salesdocument.SaleDocumentService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
 
 @Service
 public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDocumentPrintService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotSaleDocumentPrintServiceImpl.class);
     private static final String PARAM_FISCAL_DATA_ATCUD = "fiscalData_ACTUD";
+    private static final String PARAM_FISCAL_DATA_QR = "fiscalData_QR";
+    private static final String PARAM_QR_PORTUGAL = "QR_PORTUGAL";
     private static final String TAG_FISCAL_DATA = "fiscal_data";
     private static final String TAG_PROPERTY = "property";
     private static final String TAG_NAME = "name";
     private static final String TAG_VALUE = "value";
     private static final String ATCUD = "ATCUD";
+    private static final String QR = "QR";
+    private static final int QR_IMAGE_SIZE = 200;
 
     private final SaleDocumentService saleDocumentService;
     private final DocumentService documentService;
@@ -71,7 +90,7 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
     }
 
     private void populateFiscalData(IDatosSesion datosSesion, String documentUid, PrintDocumentDTO printRequest) {
-        if (printRequest == null || printRequest.getCustomParams().containsKey(PARAM_FISCAL_DATA_ATCUD)) {
+        if (printRequest == null) {
             return;
         }
 
@@ -88,16 +107,54 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
                 return;
             }
 
-            String atcud = extractAtcud(content);
-            if (StringUtils.hasText(atcud)) {
-                printRequest.getCustomParams().put(PARAM_FISCAL_DATA_ATCUD, atcud);
+            Map<String, Object> customParams = printRequest.getCustomParams();
+            FiscalDocumentData fiscalData = extractFiscalData(content);
+
+            if (!customParams.containsKey(PARAM_FISCAL_DATA_ATCUD) && StringUtils.hasText(fiscalData.getAtcud())) {
+                customParams.put(PARAM_FISCAL_DATA_ATCUD, fiscalData.getAtcud());
+            }
+
+            if (!customParams.containsKey(PARAM_FISCAL_DATA_QR) && StringUtils.hasText(fiscalData.getQr())) {
+                customParams.put(PARAM_FISCAL_DATA_QR, fiscalData.getQr());
+
+                InputStream qrStream = createQrImage(fiscalData.getQr());
+                if (qrStream != null && !customParams.containsKey(PARAM_QR_PORTUGAL)) {
+                    customParams.put(PARAM_QR_PORTUGAL, qrStream);
+                }
             }
         } catch (Exception exception) {
             LOGGER.warn("populateFiscalData() - Unable to extract fiscal data for document '{}'", documentUid, exception);
         }
     }
 
-    private String extractAtcud(byte[] xmlContent) throws Exception {
+    private FiscalDocumentData extractFiscalData(byte[] content) {
+        if (content == null || content.length == 0) {
+            return FiscalDocumentData.empty();
+        }
+
+        try {
+            if (isLikelyJson(content)) {
+                return parseFiscalDataFromJson(content);
+            }
+
+            return parseFiscalDataFromXml(content);
+        } catch (Exception exception) {
+            LOGGER.debug("extractFiscalData() - Unable to parse fiscal data as structured content", exception);
+            return FiscalDocumentData.empty();
+        }
+    }
+
+    private boolean isLikelyJson(byte[] content) {
+        for (byte candidate : content) {
+            if (candidate <= ' ') {
+                continue;
+            }
+            return candidate == '{' || candidate == '[';
+        }
+        return false;
+    }
+
+    private FiscalDocumentData parseFiscalDataFromXml(byte[] xmlContent) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
@@ -111,37 +168,46 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
             Document document = builder.parse(inputStream);
             Element root = document.getDocumentElement();
             if (root == null) {
-                return null;
+                return FiscalDocumentData.empty();
             }
 
             NodeList fiscalNodes = root.getElementsByTagName(TAG_FISCAL_DATA);
             if (fiscalNodes == null || fiscalNodes.getLength() == 0) {
-                return null;
+                return FiscalDocumentData.empty();
             }
 
-            Element fiscalDataElement = (Element) fiscalNodes.item(0);
-            NodeList propertyNodes = fiscalDataElement.getElementsByTagName(TAG_PROPERTY);
-            if (propertyNodes == null || propertyNodes.getLength() == 0) {
-                return null;
-            }
-
-            for (int i = 0; i < propertyNodes.getLength(); i++) {
-                Node node = propertyNodes.item(i);
-                if (!(node instanceof Element)) {
-                    continue;
+            FiscalDocumentData result = new FiscalDocumentData();
+            for (int index = 0; index < fiscalNodes.getLength(); index++) {
+                Node node = fiscalNodes.item(index);
+                if (node instanceof Element) {
+                    populateFromFiscalElement((Element) node, result);
                 }
-
-                Element propertyElement = (Element) node;
-                String name = getChildTextContent(propertyElement, TAG_NAME);
-                if (!ATCUD.equalsIgnoreCase(name)) {
-                    continue;
-                }
-
-                return getChildTextContent(propertyElement, TAG_VALUE);
             }
+            return result;
+        }
+    }
+
+    private void populateFromFiscalElement(Element fiscalDataElement, FiscalDocumentData result) {
+        if (fiscalDataElement == null) {
+            return;
         }
 
-        return null;
+        NodeList propertyNodes = fiscalDataElement.getElementsByTagName(TAG_PROPERTY);
+        if (propertyNodes == null || propertyNodes.getLength() == 0) {
+            return;
+        }
+
+        for (int i = 0; i < propertyNodes.getLength(); i++) {
+            Node node = propertyNodes.item(i);
+            if (!(node instanceof Element)) {
+                continue;
+            }
+
+            Element propertyElement = (Element) node;
+            String name = getChildTextContent(propertyElement, TAG_NAME);
+            String value = getChildTextContent(propertyElement, TAG_VALUE);
+            applyFiscalProperty(result, name, value);
+        }
     }
 
     private String getChildTextContent(Element parent, String tagName) {
@@ -161,5 +227,163 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
 
         String text = node.getTextContent();
         return StringUtils.hasText(text) ? text.trim() : null;
+    }
+
+    private FiscalDocumentData parseFiscalDataFromJson(byte[] jsonContent) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(jsonContent);
+
+        FiscalDocumentData result = new FiscalDocumentData();
+        traverseJson(rootNode, result);
+        return result;
+    }
+
+    private void traverseJson(JsonNode node, FiscalDocumentData result) {
+        if (node == null) {
+            return;
+        }
+
+        if (node.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                String key = entry.getKey();
+                JsonNode value = entry.getValue();
+
+                if (key != null && (TAG_FISCAL_DATA.equalsIgnoreCase(key) || "fiscalData".equalsIgnoreCase(key))) {
+                    parseFiscalJsonNode(value, result);
+                }
+
+                traverseJson(value, result);
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                traverseJson(child, result);
+            }
+        }
+    }
+
+    private void parseFiscalJsonNode(JsonNode fiscalNode, FiscalDocumentData result) {
+        if (fiscalNode == null) {
+            return;
+        }
+
+        if (fiscalNode.isObject()) {
+            if (fiscalNode.has(ATCUD)) {
+                applyFiscalProperty(result, ATCUD, getJsonText(fiscalNode.get(ATCUD)));
+            }
+            if (fiscalNode.has(QR)) {
+                applyFiscalProperty(result, QR, getJsonText(fiscalNode.get(QR)));
+            }
+
+            if (fiscalNode.has("properties")) {
+                parseFiscalJsonProperties(fiscalNode.get("properties"), result);
+            }
+            if (fiscalNode.has("property")) {
+                parseFiscalJsonProperties(fiscalNode.get("property"), result);
+            }
+        } else if (fiscalNode.isArray()) {
+            parseFiscalJsonProperties(fiscalNode, result);
+        }
+    }
+
+    private void parseFiscalJsonProperties(JsonNode propertiesNode, FiscalDocumentData result) {
+        if (propertiesNode == null) {
+            return;
+        }
+
+        for (JsonNode propertyNode : propertiesNode) {
+            if (propertyNode == null) {
+                continue;
+            }
+
+            if (propertyNode.isObject()) {
+                String name = getJsonText(propertyNode.get(TAG_NAME));
+                String value = getJsonText(propertyNode.get(TAG_VALUE));
+                if (!StringUtils.hasText(value)) {
+                    value = getJsonText(propertyNode.get("valor"));
+                }
+                applyFiscalProperty(result, name, value);
+            } else {
+                parseFiscalJsonNode(propertyNode, result);
+            }
+        }
+    }
+
+    private String getJsonText(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+
+        if (node.isValueNode()) {
+            String text = node.asText();
+            return StringUtils.hasText(text) ? text.trim() : null;
+        }
+
+        return null;
+    }
+
+    private void applyFiscalProperty(FiscalDocumentData result, String name, String value) {
+        if (!StringUtils.hasText(name) || !StringUtils.hasText(value) || result == null) {
+            return;
+        }
+
+        if (ATCUD.equalsIgnoreCase(name) && !StringUtils.hasText(result.getAtcud())) {
+            result.setAtcud(value.trim());
+        } else if (QR.equalsIgnoreCase(name) && !StringUtils.hasText(result.getQr())) {
+            result.setQr(value.trim());
+        }
+    }
+
+    private InputStream createQrImage(String base64Value) {
+        if (!StringUtils.hasText(base64Value)) {
+            return null;
+        }
+
+        try {
+            byte[] decoded = Base64.getDecoder().decode(base64Value.trim());
+            String qrText = new String(decoded, StandardCharsets.UTF_8);
+            if (!StringUtils.hasText(qrText)) {
+                return null;
+            }
+
+            QRCodeWriter writer = new QRCodeWriter();
+            BitMatrix bitMatrix = writer.encode(qrText, BarcodeFormat.QR_CODE, QR_IMAGE_SIZE, QR_IMAGE_SIZE);
+            BufferedImage qrImage = MatrixToImageWriter.toBufferedImage(bitMatrix);
+
+            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                ImageIO.write(qrImage, "jpeg", outputStream);
+                return new ByteArrayInputStream(outputStream.toByteArray());
+            }
+        } catch (IllegalArgumentException | IOException | WriterException exception) {
+            LOGGER.warn("createQrImage() - Unable to generate QR image from fiscal data", exception);
+        }
+
+        return null;
+    }
+
+    private static final class FiscalDocumentData {
+        private String atcud;
+        private String qr;
+
+        static FiscalDocumentData empty() {
+            return new FiscalDocumentData();
+        }
+
+        String getAtcud() {
+            return atcud;
+        }
+
+        void setAtcud(String atcud) {
+            this.atcud = atcud;
+        }
+
+        String getQr() {
+            return qr;
+        }
+
+        void setQr(String qr) {
+            this.qr = qr;
+        }
     }
 }

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
@@ -1,5 +1,6 @@
 package com.comerzzia.bricodepot.api.omnichannel.api.services.salesdocument;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
 import org.slf4j.Logger;
@@ -8,27 +9,48 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import com.comerzzia.api.core.service.exception.ApiException;
 import com.comerzzia.bricodepot.api.omnichannel.api.domain.salesdocument.BricodepotPrintedDocument;
 import com.comerzzia.core.servicios.sesion.IDatosSesion;
 import com.comerzzia.omnichannel.domain.dto.saledoc.PrintDocumentDTO;
+import com.comerzzia.omnichannel.domain.entity.document.DocumentEntity;
+import com.comerzzia.omnichannel.service.document.DocumentService;
 import com.comerzzia.omnichannel.service.salesdocument.SaleDocumentService;
 
 @Service
 public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDocumentPrintService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotSaleDocumentPrintServiceImpl.class);
+    private static final String PARAM_FISCAL_DATA_ATCUD = "fiscalData_ACTUD";
+    private static final String TAG_FISCAL_DATA = "fiscal_data";
+    private static final String TAG_PROPERTY = "property";
+    private static final String TAG_NAME = "name";
+    private static final String TAG_VALUE = "value";
+    private static final String ATCUD = "ATCUD";
 
     private final SaleDocumentService saleDocumentService;
+    private final DocumentService documentService;
 
     @Autowired
-    public BricodepotSaleDocumentPrintServiceImpl(SaleDocumentService saleDocumentService) {
+    public BricodepotSaleDocumentPrintServiceImpl(SaleDocumentService saleDocumentService,
+                                                  DocumentService documentService) {
         this.saleDocumentService = saleDocumentService;
+        this.documentService = documentService;
     }
 
     @Override
     public BricodepotPrintedDocument printDocument(IDatosSesion datosSesion, String documentUid, PrintDocumentDTO printRequest) throws ApiException {
         LOGGER.debug("printDocument() - Generating sales document '{}' with mime type '{}'", documentUid, printRequest.getMimeType());
+
+        populateFiscalData(datosSesion, documentUid, printRequest);
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             saleDocumentService.printDocument(outputStream, datosSesion, documentUid, printRequest);
@@ -46,5 +68,98 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
             }
             throw new ApiException(exception.getMessage(), exception);
         }
+    }
+
+    private void populateFiscalData(IDatosSesion datosSesion, String documentUid, PrintDocumentDTO printRequest) {
+        if (printRequest == null || printRequest.getCustomParams().containsKey(PARAM_FISCAL_DATA_ATCUD)) {
+            return;
+        }
+
+        try {
+            DocumentEntity documentEntity = documentService.findById(datosSesion, documentUid);
+            if (documentEntity == null) {
+                LOGGER.debug("populateFiscalData() - Document '{}' not found, skipping fiscal data extraction", documentUid);
+                return;
+            }
+
+            byte[] content = documentEntity.getDocumentContent();
+            if (content == null || content.length == 0) {
+                LOGGER.debug("populateFiscalData() - Document '{}' has no content, skipping fiscal data extraction", documentUid);
+                return;
+            }
+
+            String atcud = extractAtcud(content);
+            if (StringUtils.hasText(atcud)) {
+                printRequest.getCustomParams().put(PARAM_FISCAL_DATA_ATCUD, atcud);
+            }
+        } catch (Exception exception) {
+            LOGGER.warn("populateFiscalData() - Unable to extract fiscal data for document '{}'", documentUid, exception);
+        }
+    }
+
+    private String extractAtcud(byte[] xmlContent) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlContent)) {
+            Document document = builder.parse(inputStream);
+            Element root = document.getDocumentElement();
+            if (root == null) {
+                return null;
+            }
+
+            NodeList fiscalNodes = root.getElementsByTagName(TAG_FISCAL_DATA);
+            if (fiscalNodes == null || fiscalNodes.getLength() == 0) {
+                return null;
+            }
+
+            Element fiscalDataElement = (Element) fiscalNodes.item(0);
+            NodeList propertyNodes = fiscalDataElement.getElementsByTagName(TAG_PROPERTY);
+            if (propertyNodes == null || propertyNodes.getLength() == 0) {
+                return null;
+            }
+
+            for (int i = 0; i < propertyNodes.getLength(); i++) {
+                Node node = propertyNodes.item(i);
+                if (!(node instanceof Element)) {
+                    continue;
+                }
+
+                Element propertyElement = (Element) node;
+                String name = getChildTextContent(propertyElement, TAG_NAME);
+                if (!ATCUD.equalsIgnoreCase(name)) {
+                    continue;
+                }
+
+                return getChildTextContent(propertyElement, TAG_VALUE);
+            }
+        }
+
+        return null;
+    }
+
+    private String getChildTextContent(Element parent, String tagName) {
+        if (parent == null) {
+            return null;
+        }
+
+        NodeList nodes = parent.getElementsByTagName(tagName);
+        if (nodes == null || nodes.getLength() == 0) {
+            return null;
+        }
+
+        Node node = nodes.item(0);
+        if (node == null) {
+            return null;
+        }
+
+        String text = node.getTextContent();
+        return StringUtils.hasText(text) ? text.trim() : null;
     }
 }

--- a/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
@@ -6,8 +6,9 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.pos.services.ticket.ITicket"/>
+        <parameter name="LOGO" class="java.io.InputStream"/>
+        <parameter name="ticket" class="com.comerzzia.pos.services.ticket.ITicket"/>
+        <parameter name="fiscalData_ACTUD" class="java.lang.String"/>
 	<parameter name="QR_PORTUGAL" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>
 	<queryString>
@@ -649,15 +650,14 @@ $P{ticket}.getCabecera().getDatosDocOrigen().getCodTicket() :
 				</textElement>
 				<textFieldExpression><![CDATA["Software Version: "+($P{ticket}.getSoftwareVersion())]]></textFieldExpression>
 			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
+                        <textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
                                 <reportElement uuid="85581467-17fc-4949-bb28-a16f878f4346" x="181" y="12" width="233" height="14">
-                                        <printWhenExpression><![CDATA[$P{ticket}.getCabecera().getFiscalData() != null &&
-$P{ticket}.getCabecera().getFiscalData().getPropertyValue("ATCUD") != null]]></printWhenExpression>
+                                        <printWhenExpression><![CDATA[$P{fiscalData_ACTUD} != null]]></printWhenExpression>
                                 </reportElement>
                                 <textElement textAlignment="Left">
                                         <font fontName="Tahoma" size="9" isBold="true"/>
                                 </textElement>
-                                <textFieldExpression><![CDATA["ATCUD: " + $P{ticket}.getCabecera().getFiscalData().getPropertyValue("ATCUD")]]></textFieldExpression>
+                                <textFieldExpression><![CDATA["ATCUD: " + $P{fiscalData_ACTUD}]]></textFieldExpression>
                         </textField>
 		</band>
 	</lastPageFooter>


### PR DESCRIPTION
## Summary
- extract the ATCUD value from stored document XML before invoking the print service
- expose the ATCUD string to Jasper reports through a dedicated parameter in the Portuguese return invoice template

## Testing
- `mvn -q -DskipTests package` *(fails: blocked while downloading com.lowagie:itext:2.1.7.js6 from jaspersoft mirrors)*

------
https://chatgpt.com/codex/tasks/task_e_68fe764cf110832bb4f23ebe10319f65