### PR TITLE
Add FR 1.1 document converter bean

### DIFF
--- a/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
+++ b/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
@@ -1,0 +1,11 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FR_1_1_Document;
+
+@Component
+@Scope("prototype")
+public class FR_1_1_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_1_Document> {
+}


### PR DESCRIPTION
## Summary
- add the missing `FR_1_1_DocumentConverter` so FR sales documents can be rendered

## Testing
- mvn -f estandar/comerzzia-omnichannel-services/pom.xml -DskipTests package *(fails: missing private Comerzzia/Jasper dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_69009a37ffb8832ba802b85fa31fd995