### PR TITLE
Ensure FR 1.1 converter bean is registered with expected name

### DIFF
--- a/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
+++ b/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
@@ -1,0 +1,12 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FR_1_1_Document;
+
+@Component("FR_1_1_DocumentConverter")
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class FR_1_1_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_1_Document> {
+}


### PR DESCRIPTION
## Summary
- explicitly name the `FR_1_1_DocumentConverter` bean so the sales document service can resolve it
- use the Spring scope constant for clarity when declaring the prototype converter

## Testing
- mvn -f estandar/comerzzia-omnichannel-services/pom.xml -DskipTests package *(fails: proprietary Comerzzia/Jasper dependencies are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69009a37ffb8832ba802b85fa31fd995