### PR TITLE
Fix bean name for FR_1_1 sales document converter

### DIFF
--- a/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
+++ b/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 
 import com.comerzzia.omnichannel.model.documents.sales.FR_1_1_Document;
 
-@Component
+@Component("FR_1_1_DocumentConverter")
 @Scope("prototype")
 public class FR_1_1_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_1_Document> {
 }


### PR DESCRIPTION
## Summary
- assign the FR_1_1 sales document converter component an explicit bean name matching the expected lookup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900a014bb60832ba7b0ff3aec0b43b7