### PR TITLE
Add FR_1_1 sales document converter

### DIFF
--- a/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
+++ b/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
@@ -1,0 +1,11 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FR_1_1_Document;
+
+@Component
+@Scope("prototype")
+public class FR_1_1_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_1_Document> {
+}


### PR DESCRIPTION
## Summary
- register an FR_1_1 sales document converter bean so FR documents can be handled like other invoice types

## Testing
- mvn -q -DskipTests package *(fails: blocked mirror for jaspersoft repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6900a1838ef8832bb5d65937da2adb5b