### PR TITLE
Handle ticket-rooted XML in sale document converter

### DIFF
--- a/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/AbstractTicketVentaAbonoConverter.java
+++ b/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/AbstractTicketVentaAbonoConverter.java
@@ -2,12 +2,12 @@ package com.comerzzia.omnichannel.service.salesdocument.converters;
 
 import java.io.OutputStream;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -101,20 +101,46 @@ public abstract class AbstractTicketVentaAbonoConverter<T extends TicketVentaAbo
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T convert(final byte[] content) {
-		Class<T> genericType = (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), AbstractTicketVentaAbonoConverter.class);
-		
-		JAXBContext jaxbContext;
-		try {
-			jaxbContext = JAXBContext.newInstance(genericType);
+        public T convert(final byte[] content) {
+                Class<T> genericType = (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), AbstractTicketVentaAbonoConverter.class);
+                String xmlContent = new String(content, StandardCharsets.UTF_8);
 
-			Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+                try {
+                        return unmarshal(xmlContent, genericType);
+                } catch (JAXBException primaryException) {
+                        T fallback = tryTicketFallback(xmlContent, genericType);
+                        if (fallback != null) {
+                                return fallback;
+                        }
+                        throw new RuntimeException(primaryException);
+                }
+        }
 
-			return (T) jaxbUnmarshaller.unmarshal(new StringReader(new String(content, "UTF-8")));
-		} catch (JAXBException | UnsupportedEncodingException e) {
-			throw new RuntimeException(e);
-		}
-	}
+        private <R extends TicketVentaAbono> R unmarshal(String xmlContent, Class<R> type) throws JAXBException {
+                JAXBContext jaxbContext = JAXBContext.newInstance(type);
+                Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+                return type.cast(jaxbUnmarshaller.unmarshal(new StringReader(xmlContent)));
+        }
+
+        private T tryTicketFallback(String xmlContent, Class<T> targetType) {
+                try {
+                        TicketVentaAbono ticket = unmarshal(xmlContent, TicketVentaAbono.class);
+                        if (ticket == null) {
+                                return null;
+                        }
+
+                        if (targetType.isInstance(ticket)) {
+                                return targetType.cast(ticket);
+                        }
+
+                        if (modelMapper != null && TicketVentaAbono.class.isAssignableFrom(targetType)) {
+                                return modelMapper.map(ticket, targetType);
+                        }
+                } catch (JAXBException | RuntimeException ignored) {
+                        // Fallback failed, let the caller rethrow the original exception
+                }
+                return null;
+        }
 
 	@Override
 	public DocumentMetadata getMetadata(IDatosSesion datosSesion, DocumentEntity document) {

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/util/DateFormatUtil.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/util/DateFormatUtil.java
@@ -1,0 +1,152 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Utility helpers for dealing with date values that might arrive in different formats
+ * from omnichannel services. Jasper templates often receive values typed as Object or
+ * String so we need a central place to coerce them into {@link java.util.Date} safely.
+ */
+public final class DateFormatUtil {
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.systemDefault();
+
+    private static final String[] DEFAULT_PATTERNS = {
+        "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        "yyyy-MM-dd'T'HH:mm:ssXXX",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS",
+        "yyyy-MM-dd'T'HH:mm:ss",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-dd"
+    };
+
+    private static final String[] ENGLISH_PATTERNS = {
+        "EEE MMM dd HH:mm:ss zzz yyyy"
+    };
+
+    private DateFormatUtil() {
+        // utility class
+    }
+
+    /**
+     * Converts the provided value into a {@link Date} instance when possible.
+     * Supports {@link Date}, {@link Calendar}, {@link Instant}, {@link LocalDateTime},
+     * {@link OffsetDateTime}, {@link ZonedDateTime}, {@link LocalDate}, {@link Number}
+     * (treated as epoch milliseconds) and {@link CharSequence} representations using
+     * a set of known patterns.
+     *
+     * @param value value to convert, may be {@code null}
+     * @return a {@link Date} instance or {@code null} when the value cannot be converted
+     */
+    public static Date toDate(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof Date) {
+            return (Date) value;
+        }
+
+        if (value instanceof Calendar) {
+            return ((Calendar) value).getTime();
+        }
+
+        if (value instanceof Instant) {
+            return Date.from((Instant) value);
+        }
+
+        if (value instanceof OffsetDateTime) {
+            return Date.from(((OffsetDateTime) value).toInstant());
+        }
+
+        if (value instanceof ZonedDateTime) {
+            return Date.from(((ZonedDateTime) value).toInstant());
+        }
+
+        if (value instanceof LocalDateTime) {
+            return Date.from(((LocalDateTime) value).atZone(DEFAULT_ZONE).toInstant());
+        }
+
+        if (value instanceof LocalDate) {
+            return Date.from(((LocalDate) value).atStartOfDay(DEFAULT_ZONE).toInstant());
+        }
+
+        if (value instanceof Number) {
+            return new Date(((Number) value).longValue());
+        }
+
+        if (value instanceof CharSequence) {
+            return parseFromString(value.toString().trim());
+        }
+
+        return null;
+    }
+
+    /**
+     * Formats the provided value into a string using the supplied pattern. Returns
+     * {@code null} when the value cannot be parsed so Jasper can keep the field blank.
+     *
+     * @param value   value to format
+     * @param pattern formatting pattern compatible with {@link SimpleDateFormat}
+     * @return formatted string or {@code null} if the value cannot be converted
+     */
+    public static String formatDate(Object value, String pattern) {
+        Objects.requireNonNull(pattern, "pattern");
+        Date date = toDate(value);
+        if (date == null) {
+            return null;
+        }
+        return new SimpleDateFormat(pattern).format(date);
+    }
+
+    private static Date parseFromString(String text) {
+        if (text.isEmpty()) {
+            return null;
+        }
+
+        // Try numeric timestamps first
+        try {
+            long epochMillis = Long.parseLong(text);
+            return new Date(epochMillis);
+        } catch (NumberFormatException ignored) {
+            // continue with pattern parsing
+        }
+
+        for (String pattern : DEFAULT_PATTERNS) {
+            Date parsed = tryParseWithPattern(text, pattern, Locale.getDefault());
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+
+        for (String pattern : ENGLISH_PATTERNS) {
+            Date parsed = tryParseWithPattern(text, pattern, Locale.ENGLISH);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static Date tryParseWithPattern(String text, String pattern, Locale locale) {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern, locale);
+        simpleDateFormat.setLenient(true);
+        try {
+            return simpleDateFormat.parse(text);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/informes/ventas/facturas/facturaA4.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4.jrxml
@@ -280,20 +280,20 @@
 				</textElement>
 				<text><![CDATA[Fecha ticket:]]></text>
 			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement x="71" y="17" width="192" height="11" uuid="6c165bfc-b21d-4f14-99b8-ea23bbf157e2"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="71" y="39" width="192" height="11" uuid="e22d368d-0b86-4350-992a-c4d9aa819bac"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="71" y="17" width="192" height="11" uuid="6c165bfc-b21d-4f14-99b8-ea23bbf157e2"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="71" y="39" width="192" height="11" uuid="e22d368d-0b86-4350-992a-c4d9aa819bac"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<staticText>
 				<reportElement x="5" y="6" width="66" height="11" uuid="7a081966-3c4b-434e-8aa3-5523d03ec731"/>
 				<textElement>
@@ -341,7 +341,7 @@
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9" isBold="false"/>
 				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getIdTicket()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getIdTicket()]]></textFieldExpression>
 			</textField>
 			<componentElement>
 				<reportElement x="324" y="17" width="211" height="30" uuid="3b046719-e05a-492c-9aa3-f9b39561cb91"/>
@@ -440,13 +440,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getCliente().getDesCliente()]]></textFieldExpression>
 			</textField>
-			<textField>
-				<reportElement x="71" y="61" width="192" height="11" uuid="e4816aab-5a29-4254-bbd4-5235d05e5ef8"/>
-				<textElement>
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="71" y="61" width="192" height="11" uuid="e4816aab-5a29-4254-bbd4-5235d05e5ef8"/>
+                                <textElement>
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<textField>
 				<reportElement x="71" y="72" width="192" height="11" uuid="f2a7c3a5-19f5-4847-882b-93af96b90f1b">
 					<printWhenExpression><![CDATA[$P{DEVOLUCION} == true]]></printWhenExpression>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_CA.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_CA.jrxml
@@ -525,21 +525,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getCliente().getDesCliente()]]></textFieldExpression>
 			</textField>
-			<textField>
-				<reportElement uuid="e4816aab-5a29-4254-bbd4-5235d05e5ef8" x="121" y="162" width="192" height="11"/>
-				<textElement>
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-                                <textFieldExpression><![CDATA[
-        $P{ticket}.getCabecera().getFecha() == null
-                ? ""
-                : new java.text.SimpleDateFormat("dd/MM/yyyy").format(
-                        $P{ticket}.getCabecera().getFecha() instanceof java.util.Date
-                                ? (java.util.Date) $P{ticket}.getCabecera().getFecha()
-                                : new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse($P{ticket}.getCabecera().getFecha().toString())
-                )
-        ]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement uuid="e4816aab-5a29-4254-bbd4-5235d05e5ef8" x="121" y="162" width="192" height="11"/>
+                                <textElement>
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<textField>
 				<reportElement uuid="f2a7c3a5-19f5-4847-882b-93af96b90f1b" x="121" y="173" width="192" height="11">
 					<printWhenExpression><![CDATA[$P{DEVOLUCION} == true]]></printWhenExpression>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_Original.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_Original.jrxml
@@ -525,21 +525,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getCliente().getDesCliente()]]></textFieldExpression>
 			</textField>
-			<textField>
-				<reportElement uuid="e4816aab-5a29-4254-bbd4-5235d05e5ef8" x="105" y="163" width="192" height="11"/>
-				<textElement>
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-                                <textFieldExpression><![CDATA[
-        $P{ticket}.getCabecera().getFecha() == null
-                ? ""
-                : new java.text.SimpleDateFormat("dd/MM/yyyy").format(
-                        $P{ticket}.getCabecera().getFecha() instanceof java.util.Date
-                                ? (java.util.Date) $P{ticket}.getCabecera().getFecha()
-                                : new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse($P{ticket}.getCabecera().getFecha().toString())
-                )
-        ]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement uuid="e4816aab-5a29-4254-bbd4-5235d05e5ef8" x="105" y="163" width="192" height="11"/>
+                                <textElement>
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<textField>
 				<reportElement uuid="f2a7c3a5-19f5-4847-882b-93af96b90f1b" x="105" y="174" width="192" height="11">
 					<printWhenExpression><![CDATA[$P{DEVOLUCION} == true]]></printWhenExpression>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_PT.jrxml
@@ -512,21 +512,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{numPedido}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement uuid="e22d368d-0b86-4350-992a-c4d9aa819bac" x="110" y="163" width="192" height="11"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-                                <textFieldExpression><![CDATA[
-        $P{ticket}.getCabecera().getFecha() == null
-                ? ""
-                : new java.text.SimpleDateFormat("dd/MM/yyyy").format(
-                        $P{ticket}.getCabecera().getFecha() instanceof java.util.Date
-                                ? (java.util.Date) $P{ticket}.getCabecera().getFecha()
-                                : new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse($P{ticket}.getCabecera().getFecha().toString())
-                )
-        ]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement uuid="e22d368d-0b86-4350-992a-c4d9aa819bac" x="110" y="163" width="192" height="11"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<staticText>
 				<reportElement uuid="7a081966-3c4b-434e-8aa3-5523d03ec731" x="8" y="119" width="102" height="11"/>
 				<textElement>

--- a/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
@@ -324,20 +324,20 @@
 				</textElement>
 				<text><![CDATA[Fecha ticket]]></text>
 			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement x="91" y="17" width="127" height="11" uuid="6c165bfc-b21d-4f14-99b8-ea23bbf157e2"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="91" y="39" width="127" height="11" uuid="e22d368d-0b86-4350-992a-c4d9aa819bac"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="91" y="17" width="127" height="11" uuid="6c165bfc-b21d-4f14-99b8-ea23bbf157e2"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement x="91" y="39" width="127" height="11" uuid="e22d368d-0b86-4350-992a-c4d9aa819bac"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<staticText>
 				<reportElement x="257" y="228" width="40" height="16" uuid="e58fe4c0-4a50-4ef2-904b-3a5968bf9195"/>
 				<textElement textAlignment="Center" verticalAlignment="Bottom">
@@ -425,7 +425,7 @@ Neto]]></text>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getIdTicket()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getIdTicket()]]></textFieldExpression>
 			</textField>
 			<componentElement>
 				<reportElement x="383" y="7" width="152" height="30" uuid="3b046719-e05a-492c-9aa3-f9b39561cb91"/>

--- a/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT_OLD.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT_OLD.jrxml
@@ -249,20 +249,20 @@
 				</textElement>
 				<text><![CDATA[Fecha ticket]]></text>
 			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement uuid="6c165bfc-b21d-4f14-99b8-ea23bbf157e2" x="91" y="17" width="127" height="11"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement uuid="e22d368d-0b86-4350-992a-c4d9aa819bac" x="91" y="39" width="127" height="11"/>
-				<textElement textAlignment="Left">
-					<font fontName="Tahoma" size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
-			</textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement uuid="6c165bfc-b21d-4f14-99b8-ea23bbf157e2" x="91" y="17" width="127" height="11"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
+                        <textField isBlankWhenNull="true">
+                                <reportElement uuid="e22d368d-0b86-4350-992a-c4d9aa819bac" x="91" y="39" width="127" height="11"/>
+                                <textElement textAlignment="Left">
+                                        <font fontName="Tahoma" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[com.comerzzia.bricodepot.api.omnichannel.api.util.DateFormatUtil.formatDate($P{ticket}.getCabecera().getFecha(), "dd/MM/yyyy")]]></textFieldExpression>
+                        </textField>
 			<staticText>
 				<reportElement uuid="e58fe4c0-4a50-4ef2-904b-3a5968bf9195" x="257" y="228" width="40" height="16"/>
 				<textElement textAlignment="Center" verticalAlignment="Bottom">
@@ -365,7 +365,7 @@ Neto]]></text>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getIdTicket()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getIdTicket()]]></textFieldExpression>
 			</textField>
 			<componentElement>
 				<reportElement uuid="3b046719-e05a-492c-9aa3-f9b39561cb91" x="383" y="7" width="152" height="30"/>


### PR DESCRIPTION
## Summary
- allow `AbstractTicketVentaAbonoConverter` to detect ticket-rooted XML payloads and remap them to the expected document type
- reuse a shared JAXB helper that works with UTF-8 strings to avoid encoding issues during conversion

## Testing
- `mvn -q -DskipTests package` *(fails: dependency com.lowagie:itext:2.1.7.js6 blocked by offline mirrors)*

------
https://chatgpt.com/codex/tasks/task_e_6900adbd0414832bbaf90361cd68c38d