### PR TITLE
Fix FR converter to use ticket model

### DIFF
--- a/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FR_1_1_Document.java
+++ b/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FR_1_1_Document.java
@@ -1,0 +1,12 @@
+package com.comerzzia.omnichannel.model.documents.sales;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono;
+
+@XmlRootElement(name = "ticket")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class FR_1_1_Document extends TicketVentaAbono {
+}

--- a/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
+++ b/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_1_DocumentConverter.java
@@ -1,0 +1,11 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FR_1_1_Document;
+
+@Component
+@Scope("prototype")
+public class FR_1_1_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_1_Document> {
+}


### PR DESCRIPTION
## Summary
- adjust the FR 1.1 document model to extend the same ticket class as the other sales documents

## Testing
- mvn -q -DskipTests package *(fails: blocked mirror for jaspersoft repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6900a1838ef8832bb5d65937da2adb5b