### PR TITLE
Ensure duplicated sales documents display copy label

### DIFF
--- a/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/documentprint/AbstractDocumentPrintService.java
+++ b/estandar/comerzzia-omnichannel-services/src/main/java/com/comerzzia/omnichannel/service/documentprint/AbstractDocumentPrintService.java
@@ -94,8 +94,12 @@ public abstract class AbstractDocumentPrintService {
 		docParameters.put(DocumentPrintService.PARAM_COUNTRY_ID, locale.getCountry().toLowerCase());
 		docParameters.put(DocumentPrintService.PARAM_LOCALE_ID, locale.getDisplayLanguage());
 
-		// push custom request parameters
-		docParameters.putAll(printRequest.getCustomParams());
+                // push custom request parameters
+                docParameters.putAll(printRequest.getCustomParams());
+
+                if (Boolean.TRUE.equals(printRequest.getCopy()) && !docParameters.containsKey("esDuplicado")) {
+                        docParameters.put("esDuplicado", Boolean.TRUE);
+                }
 
 		// currency
 		String currencyCode = (String) docParameters.get(DocumentPrintService.PARAM_CURRENCY_CODE);


### PR DESCRIPTION
## Summary
- propagate the copy flag from print requests to the Jasper parameter `esDuplicado`
- allow Jasper templates to render the duplicated invoice banner when requesting a copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900bd922a80832bbbd9b6b5983cede1