### PR TITLE
Add FR 1.0 document converter

### DIFF
--- a/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FR_1_0_Document.java
+++ b/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FR_1_0_Document.java
@@ -1,0 +1,12 @@
+package com.comerzzia.omnichannel.model.documents.sales;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono;
+
+@XmlRootElement(name = "ticket")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class FR_1_0_Document extends TicketVentaAbono {
+}

--- a/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_0_DocumentConverter.java
+++ b/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_0_DocumentConverter.java
@@ -1,0 +1,11 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FR_1_0_Document;
+
+@Component
+@Scope("prototype")
+public class FR_1_0_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_0_Document> {
+}


### PR DESCRIPTION
## Summary
- add FR_1_0_Document model mirroring other ticket schemas
- expose a prototype-scoped FR_1_0_DocumentConverter bean for Spring lookup

## Testing
- mvn -q -pl . -am test -DskipTests *(fails: command hung so it was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6900e1ff8814832b9aa54de2acf3158c