### PR TITLE
Align invoice templates with new ticket model

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -5,10 +5,15 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -28,6 +33,7 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotDocumentPrintService.class);
     private static final Set<String> COMPILED_TEMPLATES = ConcurrentHashMap.newKeySet();
+    private static final ConcurrentMap<String, File> TEMPLATE_RESOLUTION_CACHE = new ConcurrentHashMap<>();
 
     @Override
     protected File getTemplateLocaleFile(String template, String localeId) {
@@ -210,9 +216,21 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
         }
 
         File candidate = buildTemplateCandidate(basePath + template, localeId);
-        if (!candidate.exists() && template.contains("/")) {
+        if (candidate.exists()) {
+            return candidate;
+        }
+
+        if (template.contains("/")) {
             String normalizedTemplate = template.replace('/', File.separatorChar);
-            candidate = buildTemplateCandidate(basePath + normalizedTemplate, localeId);
+            File normalizedCandidate = buildTemplateCandidate(basePath + normalizedTemplate, localeId);
+            if (normalizedCandidate.exists()) {
+                return normalizedCandidate;
+            }
+        } else {
+            File resolved = locateTemplateInReportsDirectory(basePath, template, localeId);
+            if (resolved != null) {
+                return resolved;
+            }
         }
 
         return candidate;
@@ -235,6 +253,66 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
         }
 
         return result;
+    }
+
+    private File locateTemplateInReportsDirectory(String basePath, String template, String localeId) {
+        if (StringUtils.isBlank(basePath) || StringUtils.isBlank(template)) {
+            return null;
+        }
+
+        File baseDirectory = new File(basePath);
+        if (!baseDirectory.isDirectory()) {
+            return null;
+        }
+
+        for (String candidateName : buildCandidateNames(template, localeId)) {
+            File cached = TEMPLATE_RESOLUTION_CACHE.get(candidateName);
+            if (cached != null) {
+                if (cached.exists()) {
+                    return cached;
+                }
+                TEMPLATE_RESOLUTION_CACHE.remove(candidateName);
+            }
+
+            File located = searchTemplateRecursively(baseDirectory, candidateName);
+            if (located != null) {
+                TEMPLATE_RESOLUTION_CACHE.put(candidateName, located);
+                return located;
+            }
+        }
+
+        return null;
+    }
+
+    private List<String> buildCandidateNames(String template, String localeId) {
+        String extension = getTemplateExtension();
+        List<String> candidates = new ArrayList<>(3);
+        String locale = localeId != null ? localeId.toLowerCase(Locale.ROOT) : null;
+
+        if (StringUtils.isNotBlank(locale)) {
+            candidates.add(template + "_" + locale + extension);
+            if (locale.length() >= 2) {
+                candidates.add(template + "_" + StringUtils.left(locale, 2) + extension);
+            }
+        }
+
+        candidates.add(template + extension);
+        return candidates;
+    }
+
+    private File searchTemplateRecursively(File baseDirectory, String candidateName) {
+        try (Stream<Path> paths = Files.walk(baseDirectory.toPath())) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> candidateName.equalsIgnoreCase(path.getFileName().toString()))
+                    .findFirst()
+                    .map(Path::toFile)
+                    .orElse(null);
+        } catch (IOException exception) {
+            LOGGER.warn("locateTemplateInReportsDirectory() - Unable to resolve template '{}' under '{}'", candidateName,
+                    baseDirectory.getAbsolutePath(), exception);
+            return null;
+        }
     }
 
     private static final class JrxmlFilter implements FileFilter {

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/JasperDateUtils.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/JasperDateUtils.java
@@ -1,0 +1,208 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.TimeZone;
+
+/**
+ * Utility helpers exposed to Jasper reports to safely convert values to dates.
+ */
+public final class JasperDateUtils {
+
+    private static final String[] SIMPLE_DATE_PATTERNS = {
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd",
+            "dd/MM/yyyy HH:mm:ss",
+            "dd/MM/yyyy",
+            "yyyyMMddHHmmss"
+    };
+
+    private JasperDateUtils() {
+        // utility class
+    }
+
+    /**
+     * Attempts to normalize the supplied value into a {@link Date} instance. Supported inputs include
+     * {@link Date}, {@link Calendar}, {@link Number}, {@link CharSequence} (ISO instants, offsets and a few
+     * well-known legacy patterns) and any {@link Instant}-convertible object. The method never throws and will
+     * return {@code null} when no conversion is possible.
+     *
+     * @param value arbitrary date representation (may be {@code null})
+     * @return a {@link Date} instance or {@code null}
+     */
+    public static Date toDate(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof Date) {
+            return (Date) value;
+        }
+
+        if (value instanceof Calendar) {
+            return ((Calendar) value).getTime();
+        }
+
+        if (value instanceof Instant) {
+            return Date.from((Instant) value);
+        }
+
+        if (value instanceof Number) {
+            long epochMillis = ((Number) value).longValue();
+            return new Date(epochMillis);
+        }
+
+        if (value instanceof CharSequence) {
+            return parseFromString(value.toString().trim());
+        }
+
+        if (value instanceof OffsetDateTime) {
+            return Date.from(((OffsetDateTime) value).toInstant());
+        }
+
+        if (value instanceof ZonedDateTime) {
+            return Date.from(((ZonedDateTime) value).toInstant());
+        }
+
+        if (value instanceof LocalDateTime) {
+            return Date.from(((LocalDateTime) value).atZone(ZoneId.systemDefault()).toInstant());
+        }
+
+        if (value instanceof LocalDate) {
+            return Date.from(((LocalDate) value).atStartOfDay(ZoneId.systemDefault()).toInstant());
+        }
+
+        return parseFromString(value.toString().trim());
+    }
+
+    private static Date parseFromString(String text) {
+        if (text.isEmpty()) {
+            return null;
+        }
+
+        // epoch millis
+        if (text.chars().allMatch(Character::isDigit)) {
+            try {
+                return new Date(Long.parseLong(text));
+            } catch (NumberFormatException ignore) {
+                // fall through to other parsers
+            }
+        }
+
+        // ISO instant or offset date-time
+        Date parsed = parseIsoInstant(text);
+        if (parsed != null) {
+            return parsed;
+        }
+
+        for (String pattern : SIMPLE_DATE_PATTERNS) {
+            parsed = parseWithPattern(text, pattern);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+
+        // java.util.Date#toString() style (Tue Oct 28 09:33:21 CET 2025)
+        parsed = parseWithPattern(text, "EEE MMM dd HH:mm:ss zzz yyyy", Locale.US, TimeZone.getDefault());
+        if (parsed != null) {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    private static Date parseIsoInstant(String text) {
+        try {
+            return Date.from(Instant.parse(text));
+        } catch (DateTimeParseException ignore) {
+            // continue
+        }
+
+        try {
+            return Date.from(OffsetDateTime.parse(text).toInstant());
+        } catch (DateTimeParseException ignore) {
+            // continue
+        }
+
+        try {
+            return Date.from(ZonedDateTime.parse(text).toInstant());
+        } catch (DateTimeParseException ignore) {
+            // continue
+        }
+
+        try {
+            LocalDateTime localDateTime = LocalDateTime.parse(text, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        } catch (DateTimeParseException ignore) {
+            // continue
+        }
+
+        try {
+            LocalDate localDate = LocalDate.parse(text, DateTimeFormatter.ISO_LOCAL_DATE);
+            return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        } catch (DateTimeParseException ignore) {
+            // continue
+        }
+
+        return null;
+    }
+
+    private static Date parseWithPattern(String text, String pattern) {
+        return parseWithPattern(text, pattern, Locale.getDefault(), TimeZone.getDefault());
+    }
+
+    private static Date parseWithPattern(String text, String pattern, Locale locale, TimeZone timeZone) {
+        Objects.requireNonNull(pattern, "pattern");
+
+        SimpleDateFormat format = new SimpleDateFormat(pattern, locale);
+        format.setLenient(true);
+        format.setTimeZone(timeZone);
+
+        try {
+            return format.parse(text);
+        } catch (ParseException exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Formats the supplied value using the provided pattern once it has been converted to a {@link Date}.
+     *
+     * @param value   arbitrary date representation
+     * @param pattern output pattern compatible with {@link SimpleDateFormat}
+     * @return the formatted string or an empty string when the value cannot be converted
+     */
+    public static String format(Object value, String pattern) {
+        Date date = toDate(value);
+        if (date == null || pattern == null) {
+            return "";
+        }
+
+        SimpleDateFormat formatter = new SimpleDateFormat(pattern);
+        formatter.setLenient(true);
+        return formatter.format(date);
+    }
+
+    /**
+     * Convenience wrapper that renders the date using the {@code dd/MM/yyyy} pattern.
+     *
+     * @param value arbitrary date representation
+     * @return the formatted string or an empty string when the value cannot be converted
+     */
+    public static String formatDayMonthYear(Object value) {
+        return format(value, "dd/MM/yyyy");
+    }
+}

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
@@ -47,6 +47,7 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
     private static final String PARAM_FISCAL_DATA_ATCUD = "fiscalData_ACTUD";
     private static final String PARAM_FISCAL_DATA_QR = "fiscalData_QR";
     private static final String PARAM_QR_PORTUGAL = "QR_PORTUGAL";
+    private static final String PARAM_DUPLICATE_FLAG = "esDuplicado";
     private static final String TAG_FISCAL_DATA = "fiscal_data";
     private static final String TAG_PROPERTY = "property";
     private static final String TAG_NAME = "name";
@@ -70,6 +71,7 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
         LOGGER.debug("printDocument() - Generating sales document '{}' with mime type '{}'", documentUid, printRequest.getMimeType());
 
         populateFiscalData(datosSesion, documentUid, printRequest);
+        applyDuplicateFlag(printRequest);
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             saleDocumentService.printDocument(outputStream, datosSesion, documentUid, printRequest);
@@ -124,6 +126,18 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
             }
         } catch (Exception exception) {
             LOGGER.warn("populateFiscalData() - Unable to extract fiscal data for document '{}'", documentUid, exception);
+        }
+    }
+
+    private void applyDuplicateFlag(PrintDocumentDTO printRequest) {
+        if (printRequest == null || !Boolean.TRUE.equals(printRequest.getCopy())) {
+            return;
+        }
+
+        Map<String, Object> customParams = printRequest.getCustomParams();
+        if (!customParams.containsKey(PARAM_DUPLICATE_FLAG)) {
+            customParams.put(PARAM_DUPLICATE_FLAG, Boolean.TRUE);
+            LOGGER.debug("applyDuplicateFlag() - Flagging document copy request with parameter '{}'", PARAM_DUPLICATE_FLAG);
         }
     }
 

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/metadata/BricodepotDocumentMetadataParser.java
@@ -28,6 +28,7 @@ public class BricodepotDocumentMetadataParser extends DocumentMetadataParser {
         registerAlias(aliases, "FS", DEFAULT_FACTURA_TEMPLATE);
         registerAlias(aliases, "NC", DEFAULT_FACTURA_TEMPLATE);
         registerAlias(aliases, "VC", DEFAULT_FACTURA_TEMPLATE);
+        registerAlias(aliases, "FR", DEFAULT_FACTURA_TEMPLATE);
         registerAlias(aliases, "facturaA4", DEFAULT_FACTURA_TEMPLATE);
         registerAlias(aliases, "factura", DEFAULT_FACTURA_TEMPLATE);
         TEMPLATE_ALIASES = Collections.unmodifiableMap(aliases);

--- a/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FR_1_0_Document.java
+++ b/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FR_1_0_Document.java
@@ -1,0 +1,12 @@
+package com.comerzzia.omnichannel.model.documents.sales;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono;
+
+@XmlRootElement(name = "ticket")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class FR_1_0_Document extends TicketVentaAbono {
+}

--- a/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_0_DocumentConverter.java
+++ b/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FR_1_0_DocumentConverter.java
@@ -1,0 +1,11 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FR_1_0_Document;
+
+@Component
+@Scope("prototype")
+public class FR_1_0_DocumentConverter extends AbstractTicketVentaAbonoConverter<FR_1_0_Document> {
+}

--- a/src/main/resources/informes/ventas/facturas/SubInfPromociones.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfPromociones.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-        <parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<field name="idPromocion" class="java.lang.Long">
 		<fieldDescription><![CDATA[idPromocion]]></fieldDescription>
 	</field>

--- a/src/main/resources/informes/ventas/facturas/SubInfPromociones_CA.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfPromociones_CA.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-        <parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<field name="idPromocion" class="java.lang.Long">
 		<fieldDescription><![CDATA[idPromocion]]></fieldDescription>
 	</field>

--- a/src/main/resources/informes/ventas/facturas/SubInfPromociones_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/SubInfPromociones_PT.jrxml
@@ -6,7 +6,7 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
-        <parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<field name="idPromocion" class="java.lang.Long">
 		<fieldDescription><![CDATA[idPromocion]]></fieldDescription>
 	</field>

--- a/src/main/resources/informes/ventas/facturas/facturaA4.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4.jrxml
@@ -285,14 +285,22 @@
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[
+        com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                $P{ticket}.getCabecera().getFecha()
+        )
+        ]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement x="71" y="39" width="192" height="11" uuid="e22d368d-0b86-4350-992a-c4d9aa819bac"/>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[
+        com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                $P{ticket}.getCabecera().getFecha()
+        )
+        ]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="5" y="6" width="66" height="11" uuid="7a081966-3c4b-434e-8aa3-5523d03ec731"/>
@@ -341,7 +349,7 @@
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9" isBold="false"/>
 				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getIdTicket()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getIdTicket()]]></textFieldExpression>
 			</textField>
 			<componentElement>
 				<reportElement x="324" y="17" width="211" height="30" uuid="3b046719-e05a-492c-9aa3-f9b39561cb91"/>
@@ -445,7 +453,11 @@
 				<textElement>
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-                                <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[
+        com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                $P{ticket}.getCabecera().getFecha()
+        )
+        ]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="71" y="72" width="192" height="11" uuid="f2a7c3a5-19f5-4847-882b-93af96b90f1b">

--- a/src/main/resources/informes/ventas/facturas/facturaA4_CA.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_CA.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-        <parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="QR_ESPAÑA" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>
@@ -531,13 +531,9 @@
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
                                 <textFieldExpression><![CDATA[
-        $P{ticket}.getCabecera().getFecha() == null
-                ? ""
-                : new java.text.SimpleDateFormat("dd/MM/yyyy").format(
-                        $P{ticket}.getCabecera().getFecha() instanceof java.util.Date
-                                ? (java.util.Date) $P{ticket}.getCabecera().getFecha()
-                                : new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse($P{ticket}.getCabecera().getFecha().toString())
-                )
+        com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                $P{ticket}.getCabecera().getFecha()
+        )
         ]]></textFieldExpression>
 			</textField>
 			<textField>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_Original.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_Original.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-        <parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="QR_ESPAÑA" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>
@@ -531,13 +531,9 @@
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
                                 <textFieldExpression><![CDATA[
-        $P{ticket}.getCabecera().getFecha() == null
-                ? ""
-                : new java.text.SimpleDateFormat("dd/MM/yyyy").format(
-                        $P{ticket}.getCabecera().getFecha() instanceof java.util.Date
-                                ? (java.util.Date) $P{ticket}.getCabecera().getFecha()
-                                : new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse($P{ticket}.getCabecera().getFecha().toString())
-                )
+        com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                $P{ticket}.getCabecera().getFecha()
+        )
         ]]></textFieldExpression>
 			</textField>
 			<textField>

--- a/src/main/resources/informes/ventas/facturas/facturaA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaA4_PT.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-        <parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+        <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="QR_PORTUGAL" class="java.io.InputStream"/>
 	<parameter name="DEVOLUCION" class="java.lang.Boolean"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>
@@ -518,13 +518,9 @@
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
                                 <textFieldExpression><![CDATA[
-        $P{ticket}.getCabecera().getFecha() == null
-                ? ""
-                : new java.text.SimpleDateFormat("dd/MM/yyyy").format(
-                        $P{ticket}.getCabecera().getFecha() instanceof java.util.Date
-                                ? (java.util.Date) $P{ticket}.getCabecera().getFecha()
-                                : new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse($P{ticket}.getCabecera().getFecha().toString())
-                )
+        com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                $P{ticket}.getCabecera().getFecha()
+        )
         ]]></textFieldExpression>
 			</textField>
 			<staticText>

--- a/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+    <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="fiscalData_ACTUD" class="java.lang.String"/>
 	<parameter name="QR_PORTUGAL" class="java.io.InputStream"/>
 	<parameter name="esDuplicado" class="java.lang.Boolean"/>
@@ -329,14 +329,22 @@
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[
+            com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                    $P{ticket}.getCabecera().getFecha()
+            )
+            ]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement x="91" y="39" width="127" height="11" uuid="e22d368d-0b86-4350-992a-c4d9aa819bac"/>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                                <textFieldExpression><![CDATA[
+            com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                    $P{ticket}.getCabecera().getFecha()
+            )
+            ]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="257" y="228" width="40" height="16" uuid="e58fe4c0-4a50-4ef2-904b-3a5968bf9195"/>
@@ -425,7 +433,7 @@ Neto]]></text>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getIdTicket()]]></textFieldExpression>
+                            <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getIdTicket()]]></textFieldExpression>
 			</textField>
 			<componentElement>
 				<reportElement x="383" y="7" width="152" height="30" uuid="3b046719-e05a-492c-9aa3-f9b39561cb91"/>

--- a/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT_OLD.jrxml
+++ b/src/main/resources/informes/ventas/facturas/facturaDevolucionA4_PT_OLD.jrxml
@@ -7,7 +7,7 @@
 		<defaultValueExpression><![CDATA[".//"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LOGO" class="java.io.InputStream"/>
-	<parameter name="ticket" class="com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono"/>
+    <parameter name="ticket" class="com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono"/>
 	<parameter name="QR_PORTUGAL" class="java.io.InputStream"/>
 	<queryString>
 		<![CDATA[]]>
@@ -254,14 +254,22 @@
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                            <textFieldExpression><![CDATA[
+                com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                        $P{ticket}.getCabecera().getFecha()
+                )
+                ]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement uuid="e22d368d-0b86-4350-992a-c4d9aa819bac" x="91" y="39" width="127" height="11"/>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getCabecera().getFechaAsLocale()]]></textFieldExpression>
+                            <textFieldExpression><![CDATA[
+                com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint.JasperDateUtils.formatDayMonthYear(
+                        $P{ticket}.getCabecera().getFecha()
+                )
+                ]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement uuid="e58fe4c0-4a50-4ef2-904b-3a5968bf9195" x="257" y="228" width="40" height="16"/>
@@ -365,7 +373,7 @@ Neto]]></text>
 				<textElement textAlignment="Left">
 					<font fontName="Tahoma" size="9" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{ticket}.getIdTicket()]]></textFieldExpression>
+                            <textFieldExpression><![CDATA[$P{ticket}.getCabecera().getIdTicket()]]></textFieldExpression>
 			</textField>
 			<componentElement>
 				<reportElement uuid="3b046719-e05a-492c-9aa3-f9b39561cb91" x="383" y="7" width="152" height="30"/>


### PR DESCRIPTION
## Summary
- point invoice templates and related subreports at the new `com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono` class
- normalize date rendering in A4 invoice variants by delegating to `JasperDateUtils` instead of inline parsing
- update Portuguese refund reports to read ticket metadata from `cabecera` to avoid missing accessor errors
- register the French document template alias and provide an `FR_1_0` document/converter pair so duplicate printing works for FR tickets

## Testing
- `mvn -DskipTests package` *(fails: could not download com.lowagie:itext:2.1.7.js6 because jaspersoft mirrors are blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6900bedab968832b9f27da8497c4d241