### PR TITLE
Add FT_1_1 sales document model and converter override

### DIFF
--- a/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FT_1_1_Document.java
+++ b/src/main/java/com/comerzzia/omnichannel/model/documents/sales/FT_1_1_Document.java
@@ -1,0 +1,12 @@
+package com.comerzzia.omnichannel.model.documents.sales;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.comerzzia.omnichannel.model.documents.sales.ticket.TicketVentaAbono;
+
+@XmlRootElement(name = "ticket")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class FT_1_1_Document extends TicketVentaAbono {
+}

--- a/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FT_1_1_DocumentConverter.java
+++ b/src/main/java/com/comerzzia/omnichannel/service/salesdocument/converters/FT_1_1_DocumentConverter.java
@@ -1,0 +1,11 @@
+package com.comerzzia.omnichannel.service.salesdocument.converters;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.omnichannel.model.documents.sales.FT_1_1_Document;
+
+@Component
+@Scope("prototype")
+public class FT_1_1_DocumentConverter extends AbstractTicketVentaAbonoConverter<FT_1_1_Document> {
+}


### PR DESCRIPTION
## Summary
- add a local FT_1_1_Document model extending TicketVentaAbono so Jasper reports receive the expected ticket type
- register a matching FT_1_1 document converter bean that leverages the existing TicketVentaAbono converter pipeline

## Testing
- `mvn -q -DskipTests compile` *(fails: blocked from downloading com.lowagie:itext due to repository access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690466f52d38832b920aa4dad4c35027