### PR TITLE
Align Jasper ticket parameter type with runtime documents

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -382,8 +382,7 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
                         return content;
                 }
 
-                int insertIndex = content.indexOf('
-', markerIndex);
+                int insertIndex = content.indexOf('\n', markerIndex);
                 if (insertIndex < 0) {
                         insertIndex = markerIndex + marker.length();
                 }
@@ -408,10 +407,10 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 	}
 
         private static final Pattern PROPERTY_PATTERN = Pattern.compile(
-                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty\\(\\\\"ATCUD\\\\"\\)"
+                "\$P\{ticket\}\.getCabecera\(\)\.getFiscalData\(\)\s*\.getProperty\(\"ATCUD\"\)"
         );
         private static final Pattern PROPERTY_VALUE_PATTERN = Pattern.compile(
-                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty(?:Value)?\\(\\\\"ATCUD\\\\"\\)(?:\\s*\\.getValue\\(\\))?"
+                "\$P\{ticket\}\.getCabecera\(\)\.getFiscalData\(\)\s*\.getProperty(?:Value)?\(\"ATCUD\"\)(?:\s*\.getValue\(\))?"
         );
         private static final String FISCAL_PARAM_REPLACEMENT = Matcher.quoteReplacement("$P{fiscalData_ACTUD}");
         private static final Pattern TICKET_PARAMETER_PATTERN = Pattern.compile(

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -1,12 +1,17 @@
 package com.comerzzia.bricodepot.api.omnichannel.api.services.documentprint;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -27,6 +32,8 @@ import com.comerzzia.omnichannel.service.documentprint.jasper.JasperPrintService
 
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperCompileManager;
+import net.sf.jasperreports.engine.design.JasperDesign;
+import net.sf.jasperreports.engine.xml.JRXmlLoader;
 
 @Service
 @Primary
@@ -69,12 +76,11 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 			return;
 		}
 
-                normalizeTicketParameterType(jrxmlFile);
-                ensurePortugueseTemplateCompatibility(jrxmlFile);
-		ensureParentDirectory(jasperFile);
+                ensureParentDirectory(jasperFile);
 
 		try {
-			JasperCompileManager.compileReportToFile(jrxmlFile.getAbsolutePath(), jasperFile.getAbsolutePath());
+			JasperDesign design = loadPatchedDesign(jrxmlFile);
+			JasperCompileManager.compileReportToFile(design, jasperFile.getAbsolutePath());
 			COMPILED_TEMPLATES.add(absolutePath);
 			compileSiblingTemplates(jrxmlFile.getParentFile(), jrxmlFile);
 		}
@@ -83,111 +89,6 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 		}
 	}
 
-        private void normalizeTicketParameterType(File jrxmlFile) {
-                if (jrxmlFile == null || !jrxmlFile.exists()) {
-                        return;
-                }
-
-                String absolutePath = jrxmlFile.getAbsolutePath();
-                if (!absolutePath.contains(File.separator + "informes" + File.separator)) {
-                        return;
-                }
-
-                try {
-                        String content = new String(Files.readAllBytes(jrxmlFile.toPath()), StandardCharsets.UTF_8);
-                        Matcher matcher = TICKET_PARAMETER_PATTERN.matcher(content);
-                        StringBuffer buffer = new StringBuffer(content.length());
-                        boolean updated = false;
-
-                        while (matcher.find()) {
-                                String currentClass = matcher.group(2);
-                                if (!NEW_TICKET_PARAMETER_CLASS.equals(currentClass)) {
-                                        matcher.appendReplacement(buffer,
-                                                matcher.group(1) + Matcher.quoteReplacement(NEW_TICKET_PARAMETER_CLASS)
-                                                        + matcher.group(3));
-                                        updated = true;
-                                }
-                                else {
-                                        matcher.appendReplacement(buffer, matcher.group(0));
-                                }
-                        }
-
-                        if (updated) {
-                                matcher.appendTail(buffer);
-                                Files.write(jrxmlFile.toPath(), buffer.toString().getBytes(StandardCharsets.UTF_8));
-                                LOGGER.debug("normalizeTicketParameterType() - Updated ticket parameter type in '{}'",
-                                        absolutePath);
-                        }
-                }
-                catch (IOException exception) {
-                        LOGGER.warn("normalizeTicketParameterType() - Unable to adjust ticket parameter in '{}'", absolutePath,
-                                exception);
-                }
-        }
-
-        private void ensurePortugueseTemplateCompatibility(File jrxmlFile) {
-                if (jrxmlFile == null) {
-                        return;
-                }
-
-		String name = jrxmlFile.getName();
-		if (!"facturaA4_PT.jrxml".equalsIgnoreCase(name) && !"facturaDevolucionA4_PT.jrxml".equalsIgnoreCase(name)) {
-			return;
-		}
-
-		try {
-			String content = new String(Files.readAllBytes(jrxmlFile.toPath()), StandardCharsets.UTF_8);
-			String updatedContent = patchAtcudExpressions(content);
-
-			if (!updatedContent.equals(content)) {
-				Files.write(jrxmlFile.toPath(), updatedContent.getBytes(StandardCharsets.UTF_8));
-				LOGGER.debug("ensurePortugueseTemplateCompatibility() - Patched fiscal data expressions in '{}'", jrxmlFile.getAbsolutePath());
-			}
-		}
-		catch (IOException exception) {
-			LOGGER.warn("ensurePortugueseTemplateCompatibility() - Unable to adjust template '{}'", jrxmlFile.getAbsolutePath(), exception);
-		}
-	}
-
-	private String patchAtcudExpressions(String content) {
-		if (content == null) {
-			return "";
-		}
-
-		String result = content;
-		if (!result.contains("name=\"fiscalData_ACTUD\"")) {
-			result = injectFiscalParameters(result);
-		}
-		else if (!result.contains("name=\"fiscalData_QR\"")) {
-			result = result.replace("name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>",
-			        "name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>");
-		}
-
-                result = PROPERTY_VALUE_PATTERN.matcher(result).replaceAll(FISCAL_PARAM_REPLACEMENT);
-                result = PROPERTY_PATTERN.matcher(result).replaceAll(FISCAL_PARAM_REPLACEMENT);
-
-		return result;
-	}
-
-	private String injectFiscalParameters(String content) {
-		String marker = "<parameter name=\"ticket\"";
-		int markerIndex = content.indexOf(marker);
-		if (markerIndex < 0) {
-			return content;
-		}
-
-		int insertIndex = content.indexOf('\n', markerIndex);
-		if (insertIndex < 0) {
-			insertIndex = markerIndex + marker.length();
-		}
-
-		StringBuilder builder = new StringBuilder(content.length() + 160);
-		builder.append(content, 0, insertIndex + 1);
-		builder.append("        <parameter name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n");
-		builder.append("        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>\n");
-		builder.append(content.substring(insertIndex + 1));
-		return builder.toString();
-	}
 
 	private void compileSiblingTemplates(File directory, File primaryJrxml) {
 		if (directory == null || !directory.isDirectory()) {
@@ -203,8 +104,6 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
                         if (primaryJrxml != null && primaryJrxml.equals(jrxmlFile)) {
                                 continue;
                         }
-                        normalizeTicketParameterType(jrxmlFile);
-                        ensurePortugueseTemplateCompatibility(jrxmlFile);
                         File jasperFile = toJasperFile(jrxmlFile);
                         if (jasperFile == null) {
                                 continue;
@@ -213,7 +112,8 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 
 			try {
 				if (!jasperFile.exists() || jrxmlFile.lastModified() >= jasperFile.lastModified()) {
-					JasperCompileManager.compileReportToFile(jrxmlFile.getAbsolutePath(), jasperFile.getAbsolutePath());
+					JasperDesign design = loadPatchedDesign(jrxmlFile);
+					JasperCompileManager.compileReportToFile(design, jasperFile.getAbsolutePath());
 				}
 				COMPILED_TEMPLATES.add(jasperFile.getAbsolutePath());
 			}
@@ -370,13 +270,162 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 		}
 	}
 
+	private JasperDesign loadPatchedDesign(File jrxmlFile) throws JRException {
+		if (jrxmlFile == null) {
+			throw new JRException("JRXML file is null");
+		}
+
+		try {
+			byte[] bytes = Files.readAllBytes(jrxmlFile.toPath());
+			String original = new String(bytes, StandardCharsets.UTF_8);
+			String patched = applyTemplatePatches(jrxmlFile, original);
+			try (InputStream inputStream = new ByteArrayInputStream(patched.getBytes(StandardCharsets.UTF_8))) {
+				return JRXmlLoader.load(inputStream);
+			}
+		}
+		catch (IOException exception) {
+			LOGGER.warn("loadPatchedDesign() - Unable to read template '{}' while compiling", jrxmlFile.getAbsolutePath(), exception);
+			return JRXmlLoader.load(jrxmlFile);
+		}
+	}
+
+	private String applyTemplatePatches(File jrxmlFile, String content) {
+		if (content == null) {
+			return "";
+		}
+
+		String result = content;
+		result = normalizeTicketParameterType(result);
+
+		if (isPortugueseTemplate(jrxmlFile)) {
+			result = patchAtcudExpressions(result);
+		}
+
+		if (requiresCodImpPatch(jrxmlFile)) {
+			result = patchCodImpField(result);
+		}
+
+		return result;
+	}
+
+        private boolean isPortugueseTemplate(File jrxmlFile) {
+                if (jrxmlFile == null) {
+                        return false;
+                }
+                String name = jrxmlFile.getName();
+                return "facturaA4_PT.jrxml".equalsIgnoreCase(name) || "facturaDevolucionA4_PT.jrxml".equalsIgnoreCase(name);
+        }
+
+        private boolean requiresCodImpPatch(File jrxmlFile) {
+                if (jrxmlFile == null) {
+                        return false;
+                }
+                return COD_IMP_PATCH_TEMPLATES.contains(jrxmlFile.getName());
+        }
+
+	private String normalizeTicketParameterType(String content) {
+		if (StringUtils.isBlank(content)) {
+			return content;
+		}
+
+		Matcher matcher = TICKET_PARAMETER_PATTERN.matcher(content);
+		StringBuffer buffer = new StringBuffer(content.length());
+		boolean updated = false;
+
+                while (matcher.find()) {
+                        String currentClass = matcher.group(2);
+                        if (!NEW_TICKET_PARAMETER_CLASS.equals(currentClass)) {
+                                matcher.appendReplacement(buffer, matcher.group(1)
+                                        + Matcher.quoteReplacement(NEW_TICKET_PARAMETER_CLASS) + matcher.group(3));
+                                updated = true;
+                        }
+                        else {
+                                matcher.appendReplacement(buffer, matcher.group(0));
+                        }
+                }
+
+                if (updated) {
+                        matcher.appendTail(buffer);
+                        return buffer.toString();
+                }
+
+                return content;
+        }
+
+	private String patchAtcudExpressions(String content) {
+		if (StringUtils.isBlank(content)) {
+			return content;
+		}
+
+		String result = content;
+                if (!result.contains("name=\"fiscalData_ACTUD\"")) {
+                        result = injectFiscalParameters(result);
+                }
+                else if (!result.contains("name=\"fiscalData_QR\"")) {
+                        result = result.replace("name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>",
+                                "name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>");
+                }
+
+                result = PROPERTY_VALUE_PATTERN.matcher(result).replaceAll(FISCAL_PARAM_REPLACEMENT);
+                result = PROPERTY_PATTERN.matcher(result).replaceAll(FISCAL_PARAM_REPLACEMENT);
+                return result;
+        }
+
+	private String injectFiscalParameters(String content) {
+		if (StringUtils.isBlank(content)) {
+			return content;
+		}
+
+		String marker = "<parameter name=\"ticket\"";
+                int markerIndex = content.indexOf(marker);
+                if (markerIndex < 0) {
+                        return content;
+                }
+
+                int insertIndex = content.indexOf('
+', markerIndex);
+                if (insertIndex < 0) {
+                        insertIndex = markerIndex + marker.length();
+                }
+
+                StringBuilder builder = new StringBuilder(content.length() + 160);
+                builder.append(content, 0, insertIndex + 1);
+                builder.append("        <parameter name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n");
+                builder.append("        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>\n");
+                builder.append(content.substring(insertIndex + 1));
+                return builder.toString();
+        }
+
+	private String patchCodImpField(String content) {
+		if (StringUtils.isBlank(content)) {
+			return content;
+		}
+
+		String patched = COD_IMP_FIELD_PATTERN.matcher(content).replaceAll("<![CDATA[codImpuesto]]>");
+		patched = patched.replace("name=\"codImp\"", "name=\"codImpuesto\"");
+		patched = patched.replace("$F{codImp", "$F{codImpuesto");
+		return patched;
+	}
+
         private static final Pattern PROPERTY_PATTERN = Pattern.compile(
-                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty\\(\\\"ATCUD\\\"\\)");
+                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty\\(\\\\"ATCUD\\\\"\\)"
+        );
         private static final Pattern PROPERTY_VALUE_PATTERN = Pattern.compile(
-                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty(?:Value)?\\(\\\"ATCUD\\\"\\)(?:\\s*\\.getValue\\(\\))?");
+                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty(?:Value)?\\(\\\\"ATCUD\\\\"\\)(?:\\s*\\.getValue\\(\\))?"
+        );
         private static final String FISCAL_PARAM_REPLACEMENT = Matcher.quoteReplacement("$P{fiscalData_ACTUD}");
         private static final Pattern TICKET_PARAMETER_PATTERN = Pattern.compile(
-                "(<parameter\\s+name=\\\"ticket\\\"\\s+class=\\\")(.*?)(\\\"\\s*/>)");
-        private static final String NEW_TICKET_PARAMETER_CLASS =
-                "com.comerzzia.omnichannel.model.documents.sales.FT_1_1_Document";
+                "(<parameter\\s+name=\\\"ticket\\\"\\s+class=\\\")(.*?)(\\\"\\s*/>)"
+        );
+	private static final String NEW_TICKET_PARAMETER_CLASS =
+		"com.comerzzia.omnichannel.model.documents.sales.FT_1_1_Document";
+	private static final Set<String> COD_IMP_PATCH_TEMPLATES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+		"SubInfLineas.jrxml",
+		"SubInfLineas_CA.jrxml",
+		"SubInfLineas_PT.jrxml",
+		"SubInfImportes.jrxml",
+		"SubInfImportes_CA.jrxml",
+		"SubInfImportes_PT.jrxml"
+	)));
+	private static final Pattern COD_IMP_FIELD_PATTERN = Pattern.compile("<!\\[CDATA\\[codImp\\]\\]>");
 }

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -68,7 +69,8 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 			return;
 		}
 
-		ensurePortugueseTemplateCompatibility(jrxmlFile);
+                normalizeTicketParameterType(jrxmlFile);
+                ensurePortugueseTemplateCompatibility(jrxmlFile);
 		ensureParentDirectory(jasperFile);
 
 		try {
@@ -81,10 +83,52 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 		}
 	}
 
-	private void ensurePortugueseTemplateCompatibility(File jrxmlFile) {
-		if (jrxmlFile == null) {
-			return;
-		}
+        private void normalizeTicketParameterType(File jrxmlFile) {
+                if (jrxmlFile == null || !jrxmlFile.exists()) {
+                        return;
+                }
+
+                String absolutePath = jrxmlFile.getAbsolutePath();
+                if (!absolutePath.contains(File.separator + "informes" + File.separator)) {
+                        return;
+                }
+
+                try {
+                        String content = new String(Files.readAllBytes(jrxmlFile.toPath()), StandardCharsets.UTF_8);
+                        Matcher matcher = TICKET_PARAMETER_PATTERN.matcher(content);
+                        StringBuffer buffer = new StringBuffer(content.length());
+                        boolean updated = false;
+
+                        while (matcher.find()) {
+                                String currentClass = matcher.group(2);
+                                if (!NEW_TICKET_PARAMETER_CLASS.equals(currentClass)) {
+                                        matcher.appendReplacement(buffer,
+                                                matcher.group(1) + Matcher.quoteReplacement(NEW_TICKET_PARAMETER_CLASS)
+                                                        + matcher.group(3));
+                                        updated = true;
+                                }
+                                else {
+                                        matcher.appendReplacement(buffer, matcher.group(0));
+                                }
+                        }
+
+                        if (updated) {
+                                matcher.appendTail(buffer);
+                                Files.write(jrxmlFile.toPath(), buffer.toString().getBytes(StandardCharsets.UTF_8));
+                                LOGGER.debug("normalizeTicketParameterType() - Updated ticket parameter type in '{}'",
+                                        absolutePath);
+                        }
+                }
+                catch (IOException exception) {
+                        LOGGER.warn("normalizeTicketParameterType() - Unable to adjust ticket parameter in '{}'", absolutePath,
+                                exception);
+                }
+        }
+
+        private void ensurePortugueseTemplateCompatibility(File jrxmlFile) {
+                if (jrxmlFile == null) {
+                        return;
+                }
 
 		String name = jrxmlFile.getName();
 		if (!"facturaA4_PT.jrxml".equalsIgnoreCase(name) && !"facturaDevolucionA4_PT.jrxml".equalsIgnoreCase(name)) {
@@ -119,8 +163,8 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 			        "name=\"fiscalData_ACTUD\" class=\"java.lang.String\"/>\n        <parameter name=\"fiscalData_QR\" class=\"java.lang.String\"/>");
 		}
 
-		result = PROPERTY_VALUE_PATTERN.matcher(result).replaceAll("$P{fiscalData_ACTUD}");
-		result = PROPERTY_PATTERN.matcher(result).replaceAll("$P{fiscalData_ACTUD}");
+                result = PROPERTY_VALUE_PATTERN.matcher(result).replaceAll(FISCAL_PARAM_REPLACEMENT);
+                result = PROPERTY_PATTERN.matcher(result).replaceAll(FISCAL_PARAM_REPLACEMENT);
 
 		return result;
 	}
@@ -155,14 +199,16 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 			return;
 		}
 
-		for (File jrxmlFile : jrxmlFiles) {
-			if (primaryJrxml != null && primaryJrxml.equals(jrxmlFile)) {
-				continue;
-			}
-			File jasperFile = toJasperFile(jrxmlFile);
-			if (jasperFile == null) {
-				continue;
-			}
+                for (File jrxmlFile : jrxmlFiles) {
+                        if (primaryJrxml != null && primaryJrxml.equals(jrxmlFile)) {
+                                continue;
+                        }
+                        normalizeTicketParameterType(jrxmlFile);
+                        ensurePortugueseTemplateCompatibility(jrxmlFile);
+                        File jasperFile = toJasperFile(jrxmlFile);
+                        if (jasperFile == null) {
+                                continue;
+                        }
 			ensureParentDirectory(jasperFile);
 
 			try {
@@ -324,7 +370,13 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 		}
 	}
 
-	private static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\.getProperty\\(\\\"ATCUD\\\"\\)");
-	private static final Pattern PROPERTY_VALUE_PATTERN = Pattern
-	        .compile("\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\.getProperty(?:Value)?\\(\\\"ATCUD\\\"\\)(?:\\.getValue\\(\\))?");
+        private static final Pattern PROPERTY_PATTERN = Pattern.compile(
+                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty\\(\\\"ATCUD\\\"\\)");
+        private static final Pattern PROPERTY_VALUE_PATTERN = Pattern.compile(
+                "\\$P\\{ticket\\}\\.getCabecera\\(\\)\\.getFiscalData\\(\\)\\s*\\.getProperty(?:Value)?\\(\\\"ATCUD\\\"\\)(?:\\s*\\.getValue\\(\\))?");
+        private static final String FISCAL_PARAM_REPLACEMENT = Matcher.quoteReplacement("$P{fiscalData_ACTUD}");
+        private static final Pattern TICKET_PARAMETER_PATTERN = Pattern.compile(
+                "(<parameter\\s+name=\\\"ticket\\\"\\s+class=\\\")(.*?)(\\\"\\s*/>)");
+        private static final String NEW_TICKET_PARAMETER_CLASS =
+                "com.comerzzia.omnichannel.model.documents.sales.FT_1_1_Document";
 }


### PR DESCRIPTION
## Summary
- ensure invoice JRXML ticket parameter definitions are rewritten to the runtime FT_1_1 document class before compiling
- reuse the normalization for subreports alongside the existing Portuguese fiscal data patch

## Testing
- mvn -q -DskipTests package *(fails: blocked JasperReports mirror for iText artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_69046c97c838832b838982c16dc16938