### PR TITLE
Fix medio pago enrichment hook in Jasper print service

### DIFF
--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/documentprint/BricodepotDocumentPrintService.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -28,10 +29,15 @@ import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
+import com.comerzzia.api.core.service.exception.ApiException;
+import com.comerzzia.bricodepot.backoffice.services.ventas.facturas.CargarFacturaA4Servicio;
 import com.comerzzia.core.util.config.AppInfo;
+import com.comerzzia.core.servicios.sesion.IDatosSesion;
+import com.comerzzia.omnichannel.domain.dto.saledoc.PrintDocumentDTO;
 import com.comerzzia.omnichannel.service.documentprint.jasper.JasperPrintServiceImpl;
 
 import net.sf.jasperreports.engine.JRException;
@@ -43,9 +49,46 @@ import net.sf.jasperreports.engine.xml.JRXmlLoader;
 @Primary
 public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotDocumentPrintService.class);
-	private static final Set<String> COMPILED_TEMPLATES = ConcurrentHashMap.newKeySet();
-	private static final ConcurrentMap<String, File> TEMPLATE_RESOLUTION_CACHE = new ConcurrentHashMap<>();
+        private static final Logger LOGGER = LoggerFactory.getLogger(BricodepotDocumentPrintService.class);
+        private static final Set<String> COMPILED_TEMPLATES = ConcurrentHashMap.newKeySet();
+        private static final ConcurrentMap<String, File> TEMPLATE_RESOLUTION_CACHE = new ConcurrentHashMap<>();
+
+        private final CargarFacturaA4Servicio cargarFacturaA4Servicio;
+
+        @Autowired
+        public BricodepotDocumentPrintService(CargarFacturaA4Servicio cargarFacturaA4Servicio) {
+                this.cargarFacturaA4Servicio = cargarFacturaA4Servicio;
+        }
+
+        @Override
+        protected Map<String, Object> generateDocParameters(IDatosSesion datosSesion, PrintDocumentDTO printRequest)
+                        throws ApiException {
+                enrichTicketPayments(printRequest);
+                return super.generateDocParameters(datosSesion, printRequest);
+        }
+
+        private void enrichTicketPayments(PrintDocumentDTO printRequest) {
+                if (cargarFacturaA4Servicio == null || printRequest == null) {
+                        return;
+                }
+
+                Map<String, Object> customParams = printRequest.getCustomParams();
+                if (customParams == null || customParams.isEmpty()) {
+                        return;
+                }
+
+                Object ticket = customParams.get("ticket");
+                if (ticket == null) {
+                        return;
+                }
+
+                try {
+                        cargarFacturaA4Servicio.generarMediosPago(ticket);
+                }
+                catch (Exception exception) {
+                        LOGGER.warn("enrichTicketPayments() - Unable to enrich ticket payments", exception);
+                }
+        }
 
 	@Override
 	protected File getTemplateLocaleFile(String template, String localeId) {
@@ -311,7 +354,7 @@ public class BricodepotDocumentPrintService extends JasperPrintServiceImpl {
                 result = normalizeTicketParameterType(result);
                 result = patchTicketDateFormatting(result);
                 result = patchDesgloseExpressions(result);
-
+                
                 if (isPortugueseTemplate(jrxmlFile)) {
                         result = patchAtcudExpressions(result);
                 }

--- a/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/services/salesdocument/BricodepotSaleDocumentPrintServiceImpl.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -56,23 +55,22 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
 	private static final String QR = "QR";
 	private static final int QR_IMAGE_SIZE = 200;
 
-	private final SaleDocumentService saleDocumentService;
-	private final DocumentService documentService;
-
-	@Autowired
-	public BricodepotSaleDocumentPrintServiceImpl(SaleDocumentService saleDocumentService, DocumentService documentService) {
-		this.saleDocumentService = saleDocumentService;
-		this.documentService = documentService;
-	}
+        private final SaleDocumentService saleDocumentService;
+        private final DocumentService documentService;
+        public BricodepotSaleDocumentPrintServiceImpl(SaleDocumentService saleDocumentService,
+                        DocumentService documentService) {
+                this.saleDocumentService = saleDocumentService;
+                this.documentService = documentService;
+        }
 
 	@Override
 	public BricodepotPrintableDocument printDocument(IDatosSesion datosSesion, String documentUid, PrintDocumentDTO printRequest) throws ApiException {
 		LOGGER.debug("printDocument() - Generating sales document '{}' with mime type '{}'", documentUid, printRequest.getMimeType());
 
-		populateFiscalData(datosSesion, documentUid, printRequest);
-		applyDuplicateFlag(printRequest);
+                populateFiscalData(datosSesion, documentUid, printRequest);
+                applyDuplicateFlag(printRequest);
 
-		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 			saleDocumentService.printDocument(outputStream, datosSesion, documentUid, printRequest);
 
 			String outputDocumentName = printRequest.getOutputDocumentName();
@@ -130,17 +128,17 @@ public class BricodepotSaleDocumentPrintServiceImpl implements BricodepotSaleDoc
 		}
 	}
 
-	private void applyDuplicateFlag(PrintDocumentDTO printRequest) {
-		if (printRequest == null || !Boolean.TRUE.equals(printRequest.getCopy())) {
-			return;
-		}
+        private void applyDuplicateFlag(PrintDocumentDTO printRequest) {
+                if (printRequest == null || !Boolean.TRUE.equals(printRequest.getCopy())) {
+                        return;
+                }
 
-		Map<String, Object> customParams = printRequest.getCustomParams();
-		if (!customParams.containsKey(PARAM_DUPLICATE_FLAG)) {
-			customParams.put(PARAM_DUPLICATE_FLAG, Boolean.TRUE);
-			LOGGER.debug("applyDuplicateFlag() - Flagging document copy request with parameter '{}'", PARAM_DUPLICATE_FLAG);
-		}
-	}
+                Map<String, Object> customParams = printRequest.getCustomParams();
+                if (!customParams.containsKey(PARAM_DUPLICATE_FLAG)) {
+                        customParams.put(PARAM_DUPLICATE_FLAG, Boolean.TRUE);
+                        LOGGER.debug("applyDuplicateFlag() - Flagging document copy request with parameter '{}'", PARAM_DUPLICATE_FLAG);
+                }
+        }
 
 	private FiscalDocumentData extractFiscalData(byte[] content) {
 		if (content == null || content.length == 0) {

--- a/src/main/java/com/comerzzia/bricodepot/backoffice/persistence/pagos/mediospago/MedioPagoRow.java
+++ b/src/main/java/com/comerzzia/bricodepot/backoffice/persistence/pagos/mediospago/MedioPagoRow.java
@@ -1,0 +1,34 @@
+package com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago;
+
+import java.math.BigDecimal;
+
+public class MedioPagoRow {
+
+        private String codMedioPago;
+        private String desMedioPago;
+        private BigDecimal importeTotal;
+
+        public String getCodMedioPago() {
+                return codMedioPago;
+        }
+
+        public void setCodMedioPago(String codMedioPago) {
+                this.codMedioPago = codMedioPago;
+        }
+
+        public String getDesMedioPago() {
+                return desMedioPago;
+        }
+
+        public void setDesMedioPago(String desMedioPago) {
+                this.desMedioPago = desMedioPago;
+        }
+
+        public BigDecimal getImporteTotal() {
+                return importeTotal;
+        }
+
+        public void setImporteTotal(BigDecimal importeTotal) {
+                this.importeTotal = importeTotal;
+        }
+}

--- a/src/main/java/com/comerzzia/bricodepot/backoffice/persistence/pagos/mediospago/MediosPagosMapper.java
+++ b/src/main/java/com/comerzzia/bricodepot/backoffice/persistence/pagos/mediospago/MediosPagosMapper.java
@@ -1,0 +1,13 @@
+package com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface MediosPagosMapper {
+
+        List<MedioPagoRow> getMediosPago(@Param("uidActividad") String uidActividad,
+                        @Param("uidTicket") String uidTicket);
+}

--- a/src/main/java/com/comerzzia/bricodepot/backoffice/services/ventas/facturas/CargarFacturaA4Servicio.java
+++ b/src/main/java/com/comerzzia/bricodepot/backoffice/services/ventas/facturas/CargarFacturaA4Servicio.java
@@ -1,0 +1,6 @@
+package com.comerzzia.bricodepot.backoffice.services.ventas.facturas;
+
+public interface CargarFacturaA4Servicio {
+
+        void generarMediosPago(Object ticketVenta);
+}

--- a/src/main/java/com/comerzzia/bricodepot/backoffice/services/ventas/facturas/CargarFacturaA4ServicioImpl.java
+++ b/src/main/java/com/comerzzia/bricodepot/backoffice/services/ventas/facturas/CargarFacturaA4ServicioImpl.java
@@ -1,0 +1,261 @@
+package com.comerzzia.bricodepot.backoffice.services.ventas.facturas;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ReflectionUtils;
+
+import com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago.MedioPagoRow;
+import com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago.MediosPagosMapper;
+
+@Service
+public class CargarFacturaA4ServicioImpl implements CargarFacturaA4Servicio {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(CargarFacturaA4ServicioImpl.class);
+        private static final String PROPERTY_CABECERA = "Cabecera";
+        private static final String PROPERTY_PAGOS = "Pagos";
+
+        private final MediosPagosMapper mediosPagosMapper;
+
+        @Autowired
+        public CargarFacturaA4ServicioImpl(MediosPagosMapper mediosPagosMapper) {
+                this.mediosPagosMapper = mediosPagosMapper;
+        }
+
+        @Override
+        public void generarMediosPago(Object ticketVenta) {
+                if (ticketVenta == null) {
+                        LOGGER.debug("generarMediosPago() - Ticket is null, skipping payment enrichment");
+                        return;
+                }
+
+                Object cabecera = invokeGetter(ticketVenta, PROPERTY_CABECERA);
+                if (cabecera == null) {
+                        LOGGER.debug("generarMediosPago() - Ticket '{}' has no cabecera", ticketVenta.getClass().getName());
+                        return;
+                }
+
+                String uidActividad = stringValue(invokeGetter(cabecera, "UidActividad"));
+                String uidTicket = stringValue(invokeGetter(cabecera, "UidTicket"));
+
+                if (StringUtils.isBlank(uidActividad) || StringUtils.isBlank(uidTicket)) {
+                        LOGGER.debug("generarMediosPago() - Missing activity '{}' or ticket '{}' identifiers", uidActividad,
+                                        uidTicket);
+                        return;
+                }
+
+                List<MedioPagoRow> mediosPago = mediosPagosMapper.getMediosPago(uidActividad, uidTicket);
+                if (CollectionUtils.isEmpty(mediosPago)) {
+                        LOGGER.debug("generarMediosPago() - No payment rows found for activity '{}' ticket '{}'", uidActividad,
+                                        uidTicket);
+                        clearExistingPayments(ticketVenta);
+                        return;
+                }
+
+                Map<String, Map<String, Object>> metadata = extractPaymentMetadata(ticketVenta);
+                List<PagoTicketLegacy> reconstruidos = new ArrayList<>(mediosPago.size());
+
+                for (MedioPagoRow row : mediosPago) {
+                        Map<String, Object> base = metadata.getOrDefault(normalizeKey(row.getCodMedioPago()),
+                                        Collections.emptyMap());
+                        reconstruidos.add(new PagoTicketLegacy(row, base));
+                }
+
+                replaceTicketPayments(ticketVenta, reconstruidos);
+        }
+
+        private void clearExistingPayments(Object ticketVenta) {
+                Collection<?> pagos = toCollection(invokeGetter(ticketVenta, PROPERTY_PAGOS));
+                if (pagos != null) {
+                        try {
+                                pagos.clear();
+                        }
+                        catch (UnsupportedOperationException exception) {
+                                LOGGER.debug("clearExistingPayments() - Unable to clear payment collection", exception);
+                        }
+                }
+        }
+
+        private Map<String, Map<String, Object>> extractPaymentMetadata(Object ticketVenta) {
+                Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+                Collection<?> pagos = toCollection(invokeGetter(ticketVenta, PROPERTY_PAGOS));
+                if (CollectionUtils.isEmpty(pagos)) {
+                        return result;
+                }
+
+                for (Object pago : pagos) {
+                        if (pago == null) {
+                                continue;
+                        }
+                        String codigo = normalizeKey(stringValue(invokeGetter(pago, "CodMedioPago")));
+                        if (codigo == null) {
+                                continue;
+                        }
+
+                        Map<String, Object> values = result.computeIfAbsent(codigo, key -> new HashMap<>());
+                        copyIfPresent(pago, "getPaymentId", values, "paymentId");
+                        copyIfPresent(pago, "getPaymentMethodId", values, "paymentMethodId");
+                        copyIfPresent(pago, "getDatosRespuestaPagoTarjeta", values, "datosRespuestaPagoTarjeta");
+                        mergeCollections(pago, "getGiftcards", values, "giftcards");
+                        copyIfPresent(pago, "getExtendedData", values, "extendedData");
+                        copyIfPresent(pago, "isEliminable", values, "eliminable");
+                        copyIfPresent(pago, "getEliminable", values, "eliminable");
+                        copyIfPresent(pago, "isIntroducidoPorCajero", values, "introducidoPorCajero");
+                        copyIfPresent(pago, "isMovimientoCajaInsertado", values, "movimientoCajaInsertado");
+                        copyIfPresent(pago, "getCreationDate", values, "creationDate");
+                        copyIfPresent(pago, "getFormatUtil", values, "formatUtil");
+                }
+
+                return result;
+        }
+
+        private void copyIfPresent(Object target, String methodName, Map<String, Object> destination, String key) {
+                Object value = invokeMethod(target, methodName);
+                if (value != null) {
+                        destination.put(key, value);
+                }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void mergeCollections(Object target, String methodName, Map<String, Object> destination, String key) {
+                Object value = invokeMethod(target, methodName);
+                if (!(value instanceof Collection)) {
+                        return;
+                }
+
+                Collection<Object> collection = (Collection<Object>) value;
+                if (CollectionUtils.isEmpty(collection)) {
+                        return;
+                }
+
+                List<Object> aggregated = (List<Object>) destination.computeIfAbsent(key, unused -> new ArrayList<>());
+                aggregated.addAll(collection);
+        }
+
+        private void replaceTicketPayments(Object ticketVenta, List<PagoTicketLegacy> pagos) {
+                Object existing = invokeGetter(ticketVenta, PROPERTY_PAGOS);
+                if (existing instanceof Collection) {
+                        Collection<Object> collection = castCollection(existing);
+                        try {
+                                collection.clear();
+                                collection.addAll(pagos);
+                                return;
+                        }
+                        catch (UnsupportedOperationException exception) {
+                                LOGGER.debug("replaceTicketPayments() - Payment collection is immutable, switching to setter", exception);
+                        }
+                }
+
+                Method setter = ReflectionUtils.findMethod(ticketVenta.getClass(), "set" + PROPERTY_PAGOS, List.class);
+                if (setter != null) {
+                        invokeSetter(ticketVenta, setter, new ArrayList<>(pagos));
+                        return;
+                }
+
+                Field field = ReflectionUtils.findField(ticketVenta.getClass(), PROPERTY_PAGOS.toLowerCase());
+                if (field != null) {
+                        ReflectionUtils.makeAccessible(field);
+                        try {
+                                field.set(ticketVenta, new ArrayList<>(pagos));
+                                return;
+                        }
+                        catch (IllegalAccessException exception) {
+                                LOGGER.warn("replaceTicketPayments() - Unable to set pagos field via reflection", exception);
+                        }
+                }
+
+                LOGGER.warn("replaceTicketPayments() - Unable to inject reconstructed payments into ticket class '{}'", ticketVenta.getClass().getName());
+        }
+
+        private Collection<Object> castCollection(Object value) {
+                if (value instanceof Collection) {
+                        @SuppressWarnings("unchecked")
+                        Collection<Object> casted = (Collection<Object>) value;
+                        return casted;
+                }
+                return null;
+        }
+
+        private Object invokeGetter(Object target, String property) {
+                if (target == null || StringUtils.isBlank(property)) {
+                        return null;
+                }
+
+                String methodName = "get" + property;
+                Object value = invokeMethod(target, methodName);
+                if (value != null || hasMethod(target.getClass(), methodName)) {
+                        return value;
+                }
+
+                methodName = "is" + property;
+                return invokeMethod(target, methodName);
+        }
+
+        private boolean hasMethod(Class<?> type, String methodName) {
+                return ReflectionUtils.findMethod(type, methodName) != null;
+        }
+
+        private Object invokeMethod(Object target, String methodName) {
+                if (target == null || StringUtils.isBlank(methodName)) {
+                        return null;
+                }
+
+                Method method = ReflectionUtils.findMethod(target.getClass(), methodName);
+                if (method == null) {
+                        return null;
+                }
+
+                ReflectionUtils.makeAccessible(method);
+                try {
+                        return method.invoke(target);
+                }
+                catch (Exception exception) {
+                        LOGGER.debug("invokeMethod() - Unable to execute '{}' on '{}'", methodName,
+                                        target.getClass().getName(), exception);
+                        return null;
+                }
+        }
+
+        private void invokeSetter(Object target, Method setter, Object value) {
+                ReflectionUtils.makeAccessible(setter);
+                try {
+                        setter.invoke(target, value);
+                }
+                catch (Exception exception) {
+                        LOGGER.warn("invokeSetter() - Unable to execute '{}' on '{}'", setter.getName(),
+                                        target.getClass().getName(), exception);
+                }
+        }
+
+        private String stringValue(Object value) {
+                return value != null ? Objects.toString(value, null) : null;
+        }
+
+        private Collection<?> toCollection(Object value) {
+                if (value instanceof Collection) {
+                        return (Collection<?>) value;
+                }
+                return null;
+        }
+
+        private String normalizeKey(String value) {
+                if (StringUtils.isBlank(value)) {
+                        return null;
+                }
+                return value.trim();
+        }
+}

--- a/src/main/java/com/comerzzia/bricodepot/backoffice/services/ventas/facturas/PagoTicketLegacy.java
+++ b/src/main/java/com/comerzzia/bricodepot/backoffice/services/ventas/facturas/PagoTicketLegacy.java
@@ -1,0 +1,135 @@
+package com.comerzzia.bricodepot.backoffice.services.ventas.facturas;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
+
+import com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago.MedioPagoRow;
+
+final class PagoTicketLegacy {
+
+        private final String codMedioPago;
+        private final BigDecimal importe;
+        private final MedioPago medioPago;
+
+        private final Object paymentId;
+        private final Object paymentMethodId;
+        private final Object datosRespuestaPagoTarjeta;
+        private final Collection<?> giftcards;
+        private final Object extendedData;
+        private final Boolean eliminable;
+        private final Boolean introducidoPorCajero;
+        private final Boolean movimientoCajaInsertado;
+        private final Date creationDate;
+        private final Object formatUtil;
+
+        PagoTicketLegacy(MedioPagoRow row, Map<String, Object> baseProperties) {
+                this.codMedioPago = row != null ? row.getCodMedioPago() : null;
+                this.importe = row != null ? row.getImporteTotal() : null;
+                this.medioPago = new MedioPago(row != null ? row.getCodMedioPago() : null,
+                                row != null ? row.getDesMedioPago() : null);
+
+                this.paymentId = baseProperties.get("paymentId");
+                this.paymentMethodId = baseProperties.get("paymentMethodId");
+                this.datosRespuestaPagoTarjeta = baseProperties.get("datosRespuestaPagoTarjeta");
+                Object giftcardsValue = baseProperties.get("giftcards");
+                if (giftcardsValue instanceof Collection) {
+                        Collection<?> collection = (Collection<?>) giftcardsValue;
+                        if (CollectionUtils.isEmpty(collection)) {
+                                this.giftcards = Collections.emptyList();
+                        }
+                        else {
+                                this.giftcards = Collections.unmodifiableCollection(new ArrayList<>(collection));
+                        }
+                }
+                else {
+                        this.giftcards = Collections.emptyList();
+                }
+                this.extendedData = baseProperties.get("extendedData");
+                this.eliminable = (Boolean) baseProperties.get("eliminable");
+                this.introducidoPorCajero = (Boolean) baseProperties.get("introducidoPorCajero");
+                this.movimientoCajaInsertado = (Boolean) baseProperties.get("movimientoCajaInsertado");
+                this.creationDate = (Date) baseProperties.get("creationDate");
+                this.formatUtil = baseProperties.get("formatUtil");
+        }
+
+        public String getCodMedioPago() {
+                return codMedioPago;
+        }
+
+        public String getDesMedioPago() {
+                return medioPago.getDesMedioPago();
+        }
+
+        public BigDecimal getImporte() {
+                return importe;
+        }
+
+        public MedioPago getMedioPago() {
+                return medioPago;
+        }
+
+        public Object getPaymentId() {
+                return paymentId;
+        }
+
+        public Object getPaymentMethodId() {
+                return paymentMethodId;
+        }
+
+        public Object getDatosRespuestaPagoTarjeta() {
+                return datosRespuestaPagoTarjeta;
+        }
+
+        public Collection<?> getGiftcards() {
+                return giftcards;
+        }
+
+        public Object getExtendedData() {
+                return extendedData;
+        }
+
+        public Boolean isEliminable() {
+                return eliminable;
+        }
+
+        public Boolean isIntroducidoPorCajero() {
+                return introducidoPorCajero;
+        }
+
+        public Boolean isMovimientoCajaInsertado() {
+                return movimientoCajaInsertado;
+        }
+
+        public Date getCreationDate() {
+                return creationDate;
+        }
+
+        public Object getFormatUtil() {
+                return formatUtil;
+        }
+
+        static final class MedioPago {
+
+                private final String codMedioPago;
+                private final String desMedioPago;
+
+                MedioPago(String codigo, String descripcion) {
+                        this.codMedioPago = codigo;
+                        this.desMedioPago = descripcion;
+                }
+
+                public String getCodMedioPago() {
+                        return codMedioPago;
+                }
+
+                public String getDesMedioPago() {
+                        return desMedioPago;
+                }
+        }
+}

--- a/src/main/resources/com/comerzzia/bricodepot/backoffice/persistence/pagos/mediospago/MediosPagosMapper.xml
+++ b/src/main/resources/com/comerzzia/bricodepot/backoffice/persistence/pagos/mediospago/MediosPagosMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago.MediosPagosMapper">
+
+        <resultMap id="MedioPagoRow" type="com.comerzzia.bricodepot.backoffice.persistence.pagos.mediospago.MedioPagoRow">
+                <result property="codMedioPago" column="CODMEDPAG" />
+                <result property="desMedioPago" column="DESMEDPAG" />
+                <result property="importeTotal" column="IMPORTE_TOTAL" />
+        </resultMap>
+
+        <select id="getMediosPago" parameterType="map" resultMap="MedioPagoRow">
+                SELECT
+                        PAG.UID_ACTIVIDAD,
+                        PAG.IMPORTE AS IMPORTE_TOTAL,
+                        MEDPAG.CODMEDPAG,
+                        MEDPAG.DESMEDPAG
+                FROM D_CLIE_ALBARANES_CAB_TBL CAB
+                        INNER JOIN D_CLIE_ALBARANES_PAG_TBL PAG
+                                ON (PAG.UID_ACTIVIDAD = CAB.UID_ACTIVIDAD AND PAG.ID_CLIE_ALBARAN = CAB.ID_CLIE_ALBARAN)
+                        INNER JOIN D_MEDIOS_PAGO_VEN_TBL MEDPAGVEN
+                                ON (MEDPAGVEN.UID_ACTIVIDAD = PAG.UID_ACTIVIDAD AND MEDPAGVEN.ID_MEDPAG_VEN = PAG.ID_MEDPAG_VEN)
+                        INNER JOIN D_MEDIOS_PAGO_TBL MEDPAG
+                                ON (MEDPAG.UID_ACTIVIDAD = PAG.UID_ACTIVIDAD AND MEDPAG.CODMEDPAG = MEDPAGVEN.CODMEDPAG)
+                WHERE CAB.UID_ACTIVIDAD = #{uidActividad}
+                  AND CAB.UID_TICKET = #{uidTicket}
+                ORDER BY MEDPAG.CODMEDPAG
+        </select>
+
+</mapper>


### PR DESCRIPTION
## Summary
- import the session context and ApiException types required by the Jasper print service override
- override `generateDocParameters` with the correct signature so medio pago enrichment runs before the superclass generates parameters

## Testing
- `mvn -q -DskipTests package` *(fails: missing com.lowagie:itext from the blocked Jaspersoft mirror)*

------
https://chatgpt.com/codex/tasks/task_e_69088b989200832bbfcb7cbd34399e99